### PR TITLE
doc:add L1 proxy addresses to mainnet docs

### DIFF
--- a/docs/frontier.md
+++ b/docs/frontier.md
@@ -105,11 +105,14 @@ See the [mega-tokenlist](https://github.com/megaeth-labs/mega-tokenlist) for a m
 
 | Item | Address | Remarks |
 | --------- | ------------- | ---------------------------- |
+| DisputeGameFactoryProxy             | `0x8546840adf796875cd9aacc5b3b048f6b2c9d563` | |
 | L1CrossDomainMessengerProxy         | `0x6C7198250087B29A8040eC63903Bc130f4831Cc9` | |
 | L1ERC721BridgeProxy                 | `0x3D8ee269F87A7f3F0590c5C0d825FFF06212A242` | |
 | L1StandardBridgeProxy               | `0x0CA3A2FBC3D770b578223FBB6b062fa875a2eE75` | |
-| OptimismPortalProxy                 | `0x7f82f57F0Dd546519324392e408b01fcC7D709e8` | |
 | OptimismMintableERC20FactoryProxy   | `0xF875030B9464001fC0f964E47546b0AFEEbD7C61` | |
+| OptimismPortalProxy                 | `0x7f82f57F0Dd546519324392e408b01fcC7D709e8` | |
+| ProtocolVersionsProxy               | `0x150355311f965af4937fcca526f9df0573fd5b85` | |
+| SuperchainConfigProxy               | `0x5d0ff601bc8580d8682c0462df55343cb0b99285` | |
 | SystemConfigProxy                   | `0x1ED92E1bc9A2735216540EDdD0191144681cb77E` | |
 | USDM                                | `0xEc2AF1C8B110a61fD9C3Fa6a554a031Ca9943926` | |
 

--- a/public/architecture.html
+++ b/public/architecture.html
@@ -53,19 +53,49 @@
         </header>
 
         <main class="site-content">
-            <p>The complete MegaETH system will consist of the following logical components:</p>
-            <p><strong>Sequencers.</strong> Users’ transactions (write requests) coming into the system end up with them. They execute users’ transactions, assemble executed transactions into blocks, and disseminate execution results such as transaction receipts and state changes. They also submit the blocks to the L1 for finality.</p>
-            <p><strong>Read replicas.</strong> They maintain replicas of the chain’s state and (recent) history to service read requests. They may also choose to screen write requests by validating them against local replicas of the chain’s state. Depending on how a replica maintains the state and the history, there are two types of nodes.</p>
+            <p>The complete MegaETH system will consist of the following
+            logical components:</p>
+            <p><strong>Sequencers.</strong> Users’ transactions (write
+            requests) coming into the system end up with them. They
+            execute users’ transactions, assemble executed transactions
+            into blocks, and disseminate execution results such as
+            transaction receipts and state changes. They also submit the
+            blocks to the L1 for finality.</p>
+            <p><strong>Read replicas.</strong> They maintain replicas of
+            the chain’s state and (recent) history to service read
+            requests. They may also choose to screen write requests by
+            validating them against local replicas of the chain’s state.
+            Depending on how a replica maintains the state and the
+            history, there are two types of nodes.</p>
             <ul>
-            <li><em>Replica nodes.</em> They receive new blocks and execution results and apply them to local replicas of the chain’s state and history without validation.</li>
-            <li><em>Full nodes.</em> They receive new blocks, locally re-execute the blocks, and update local replicas of the chain’s state and history.</li>
+            <li><em>Replica nodes.</em> They receive new blocks and
+            execution results and apply them to local replicas of the
+            chain’s state and history without validation.</li>
+            <li><em>Full nodes.</em> They receive new blocks, locally
+            re-execute the blocks, and update local replicas of the
+            chain’s state and history.</li>
             </ul>
-            <p><strong>Provers.</strong> They receive new blocks, locally re-execute the blocks, and generate proofs for the blocks. These proofs might be fault proofs or validity proofs, depending on how the chain is operated.</p>
-            <p><strong>Data availability (DA) service.</strong> When a sequencer produces a block, it must submit to the DA service any associated data that the rest of the network depends on to process the block; the DA service will return a receipt certifying that the data is received and make the data publicly available for a finite period of time. Without the receipt, the sequencer cannot submit the block to the L1. The DA service ensures that replica nodes and full nodes can keep up with the chain’s state, and prover nodes can produce proofs for any block that is submitted to the L1, even if the sequencer maliciously withholds data.</p>
-            <p>The current phase of the MegaETH Testnet contains the following components:</p>
+            <p><strong>Provers.</strong> They receive new blocks,
+            locally re-execute the blocks, and generate proofs for the
+            blocks. These proofs might be fault proofs or validity
+            proofs, depending on how the chain is operated.</p>
+            <p><strong>Data availability (DA) service.</strong> When a
+            sequencer produces a block, it must submit to the DA service
+            any associated data that the rest of the network depends on
+            to process the block; the DA service will return a receipt
+            certifying that the data is received and make the data
+            publicly available for a finite period of time. Without the
+            receipt, the sequencer cannot submit the block to the L1.
+            The DA service ensures that replica nodes and full nodes can
+            keep up with the chain’s state, and prover nodes can produce
+            proofs for any block that is submitted to the L1, even if
+            the sequencer maliciously withholds data.</p>
+            <p>The current phase of the MegaETH Testnet contains the
+            following components:</p>
             <ul>
             <li>One sequencer</li>
-            <li>Multiple replica nodes maintained by MegaETH to serve RPC requests</li>
+            <li>Multiple replica nodes maintained by MegaETH to serve
+            RPC requests</li>
             <li>EigenDA devnet as the DA service</li>
             <li>An Ethereum devnet as the L1</li>
             </ul>
@@ -74,7 +104,8 @@
             <li>Multiple sequencers for failover and rotation</li>
             <li>Permissionless full nodes</li>
             <li>Permissionless replica nodes</li>
-            <li>Permissionless prover nodes running in optimistic (fault proof) mode</li>
+            <li>Permissionless prover nodes running in optimistic (fault
+            proof) mode</li>
             <li>Ethereum Testnet as the L1</li>
             </ul>
         </main>

--- a/public/frontier.html
+++ b/public/frontier.html
@@ -51,18 +51,32 @@
                 
                                 <nav id="TOC">
                     <ul>
-                    <li><a href="#chain-parameters">Chain Parameters</a></li>
-                    <li><a href="#connecting-to-megaeth-mainnet">Connecting to MegaETH Mainnet</a>
+                    <li><a href="#chain-parameters"
+                    id="toc-chain-parameters">Chain Parameters</a></li>
+                    <li><a href="#connecting-to-megaeth-mainnet"
+                    id="toc-connecting-to-megaeth-mainnet">Connecting to
+                    MegaETH Mainnet</a>
                     <ul>
-                    <li><a href="#rpc">RPC</a></li>
-                    <li><a href="#block-explorer">Block Explorer</a></li>
+                    <li><a href="#rpc" id="toc-rpc">RPC</a></li>
+                    <li><a href="#block-explorer"
+                    id="toc-block-explorer">Block Explorer</a></li>
                     </ul></li>
-                    <li><a href="#developing-smart-contracts">Developing Smart Contracts</a></li>
-                    <li><a href="#using-the-canonical-bridge">Using the Canonical Bridge</a></li>
-                    <li><a href="#contracts-of-potential-interest">Contracts of Potential Interest</a>
+                    <li><a href="#developing-smart-contracts"
+                    id="toc-developing-smart-contracts">Developing Smart
+                    Contracts</a></li>
+                    <li><a href="#using-the-canonical-bridge"
+                    id="toc-using-the-canonical-bridge">Using the
+                    Canonical Bridge</a></li>
+                    <li><a href="#contracts-of-potential-interest"
+                    id="toc-contracts-of-potential-interest">Contracts
+                    of Potential Interest</a>
                     <ul>
-                    <li><a href="#on-megaeth-mainnet">On MegaETH Mainnet</a></li>
-                    <li><a href="#on-ethereum-mainnet">On Ethereum Mainnet</a></li>
+                    <li><a href="#on-megaeth-mainnet"
+                    id="toc-on-megaeth-mainnet">On MegaETH
+                    Mainnet</a></li>
+                    <li><a href="#on-ethereum-mainnet"
+                    id="toc-on-ethereum-mainnet">On Ethereum
+                    Mainnet</a></li>
                     </ul></li>
                     </ul>
                 </nav>
@@ -72,6 +86,10 @@
         <main class="site-content">
             <h2 id="chain-parameters">Chain Parameters</h2>
             <table>
+            <colgroup>
+            <col style="width: 27%" />
+            <col style="width: 72%" />
+            </colgroup>
             <thead>
             <tr class="header">
             <th>Item</th>
@@ -93,11 +111,14 @@
             </tr>
             <tr class="even">
             <td><strong>Block Gas Limit</strong></td>
-            <td>10 billion (<br /><span class="math display">10<sup>10</sup></span><br />) gas per EVM block</td>
+            <td>10 billion (<span
+            class="math display">10<sup>10</sup></span>) gas per EVM
+            block</td>
             </tr>
             <tr class="odd">
             <td><strong>Base Fee Per Gas</strong></td>
-            <td>0.001 gwei (<br /><span class="math display">10<sup>6</sup></span><br /> wei)</td>
+            <td>0.001 gwei (<span
+            class="math display">10<sup>6</sup></span> wei)</td>
             </tr>
             <tr class="even">
             <td><strong>EIP-1559 Parameters</strong></td>
@@ -105,24 +126,86 @@
             </tr>
             </tbody>
             </table>
-            <h2 id="connecting-to-megaeth-mainnet">Connecting to MegaETH Mainnet</h2>
+            <h2 id="connecting-to-megaeth-mainnet">Connecting to MegaETH
+            Mainnet</h2>
             <h3 id="rpc">RPC</h3>
-            <p>MegaETH hosts a public RPC endpoint at https://mainnet.megaeth.com/rpc.</p>
-            <p>See <a href="/realtime-api.html">Realtime API</a> for a list of additional features on top of the standard Ethereum JSON-RPC. These features are available on RPC endpoints provided by MegaETH; availability varies on third-party endpoints.</p>
+            <p>MegaETH hosts a public RPC endpoint at
+            https://mainnet.megaeth.com/rpc.</p>
+            <p>See <a href="/realtime-api.html">Realtime API</a> for a
+            list of additional features on top of the standard Ethereum
+            JSON-RPC. These features are available on RPC endpoints
+            provided by MegaETH; availability varies on third-party
+            endpoints.</p>
             <h3 id="block-explorer">Block Explorer</h3>
-            <p><a href="https://megaeth.blockscout.com/">Blockscout</a> and <a href="https://mega.etherscan.io">Etherscan</a> are available.</p>
-            <h2 id="developing-smart-contracts">Developing Smart Contracts</h2>
-            <p>MegaETH’s execution environment is called <em>MegaEVM</em>. It is fully compatible with Ethereum smart contracts but introduces a few differences compared to Ethereum’s EVM especially around the gas model. See the <a href="/megaevm.html">MegaEVM manual page</a> for a list of differences. Implementation of MegaEVM is opensource and can be found on <a href="https://github.com/megaeth-labs/mega-evm">GitHub</a>.</p>
-            <p>Because of the said differences, toolchains not yet customized for MegaETH might incorrectly estimate the amount of gas a transaction needs if they use their own EVM implementations, as opposed to MegaEVM, to locally simulate the transaction. Sometimes, this issue causes the RPC to throw “intrinsic gas too low” errors or the transaction to run out of gas and revert. The solution is to either tell the toolchain to skip local gas estimation and use a hardcoded gas limit (for <code>forge script</code>, as an example, <code>--gas-limit</code> with a sufficiently large number plus <code>--skip-simulation</code>), or use MegaETH’s RPC servers to estimate gas.</p>
-            <p><em>The best tool for debugging MegaETH transactions is <code>mega-evme</code>.</em> It uses the aforementioned opensource implementation of MegaEVM and can thus perfectly simulate any transaction’s behavior on MegaETH. Instructions on building and using <code>mega-evme</code> are available <a href="https://github.com/megaeth-labs/mega-evm/blob/main/bin/mega-evme/README.md">here</a>.</p>
-            <h2 id="using-the-canonical-bridge">Using the Canonical Bridge</h2>
-            <p>MegaETH’s canonical bridge is the preferred method to bridge Ether (ETH) from Ethereum to MegaETH. The Ethereum side of the bridge is at <code>0x0CA3A2FBC3D770b578223FBB6b062fa875a2eE75</code> on Ethereum mainnet. Currently, it runs OP Stack’s <a href="https://docs.optimism.io/app-developers/guides/bridging/standard-bridge">Standard Bridge</a> in its <a href="https://github.com/ethereum-optimism/optimism/blob/backports/op-contracts/v3.0.0/packages/contracts-bedrock/src/universal/StandardBridge.sol">op-contracts/v3.0.0 release</a> with a small patch adjusting a few parameters.</p>
-            <p>The easiest way to bridge Ether to MegaETH is sending Ether to the aforementioned address on Ethereum mainnet in a plain native transfer. The same amount of Ether sans gas fees will appear in sender’s address on MegaETH after the transfer is finalized on Ethereum mainnet.</p>
-            <p>For more control, use the <code>depositETH</code> method of the bridge contract. It allows for specifying the (approximate) amount of gas that should be charged by and forwarded from Ethereum mainnet to MegaETH for the deposit transaction to use, as well as adding extra data to the transaction. As an example, the following <code>cast send</code> command calls <code>depositETH</code> to bridge 0.001 Ether with 61000 gas and extra data <code>bunny</code>.</p>
-            <div class="sourceCode" id="cb1"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true"></a><span class="ex">cast</span> send 0x0CA3A2FBC3D770b578223FBB6b062fa875a2eE75 <span class="st">&#39;depositETH(uint32, bytes)&#39;</span> 61000 <span class="st">&quot;0x62756e6e79&quot;</span> --value 0.001ether</span></code></pre></div>
-            <h2 id="contracts-of-potential-interest">Contracts of Potential Interest</h2>
+            <p><a href="https://megaeth.blockscout.com/">Blockscout</a>
+            and <a href="https://mega.etherscan.io">Etherscan</a> are
+            available.</p>
+            <h2 id="developing-smart-contracts">Developing Smart
+            Contracts</h2>
+            <p>MegaETH’s execution environment is called
+            <em>MegaEVM</em>. It is fully compatible with Ethereum smart
+            contracts but introduces a few differences compared to
+            Ethereum’s EVM especially around the gas model. See the <a
+            href="/megaevm.html">MegaEVM manual page</a> for a list of
+            differences. Implementation of MegaEVM is opensource and can
+            be found on <a
+            href="https://github.com/megaeth-labs/mega-evm">GitHub</a>.</p>
+            <p>Because of the said differences, toolchains not yet
+            customized for MegaETH might incorrectly estimate the amount
+            of gas a transaction needs if they use their own EVM
+            implementations, as opposed to MegaEVM, to locally simulate
+            the transaction. Sometimes, this issue causes the RPC to
+            throw “intrinsic gas too low” errors or the transaction to
+            run out of gas and revert. The solution is to either tell
+            the toolchain to skip local gas estimation and use a
+            hardcoded gas limit (for <code>forge script</code>, as an
+            example, <code>--gas-limit</code> with a sufficiently large
+            number plus <code>--skip-simulation</code>), or use
+            MegaETH’s RPC servers to estimate gas.</p>
+            <p><em>The best tool for debugging MegaETH transactions is
+            <code>mega-evme</code>.</em> It uses the aforementioned
+            opensource implementation of MegaEVM and can thus perfectly
+            simulate any transaction’s behavior on MegaETH. Instructions
+            on building and using <code>mega-evme</code> are available
+            <a
+            href="https://github.com/megaeth-labs/mega-evm/blob/main/bin/mega-evme/README.md">here</a>.</p>
+            <h2 id="using-the-canonical-bridge">Using the Canonical
+            Bridge</h2>
+            <p>MegaETH’s canonical bridge is the preferred method to
+            bridge Ether (ETH) from Ethereum to MegaETH. The Ethereum
+            side of the bridge is at
+            <code>0x0CA3A2FBC3D770b578223FBB6b062fa875a2eE75</code> on
+            Ethereum mainnet. Currently, it runs OP Stack’s <a
+            href="https://docs.optimism.io/app-developers/guides/bridging/standard-bridge">Standard
+            Bridge</a> in its <a
+            href="https://github.com/ethereum-optimism/optimism/blob/backports/op-contracts/v3.0.0/packages/contracts-bedrock/src/universal/StandardBridge.sol">op-contracts/v3.0.0
+            release</a> with a small patch adjusting a few
+            parameters.</p>
+            <p>The easiest way to bridge Ether to MegaETH is sending
+            Ether to the aforementioned address on Ethereum mainnet in a
+            plain native transfer. The same amount of Ether sans gas
+            fees will appear in sender’s address on MegaETH after the
+            transfer is finalized on Ethereum mainnet.</p>
+            <p>For more control, use the <code>depositETH</code> method
+            of the bridge contract. It allows for specifying the
+            (approximate) amount of gas that should be charged by and
+            forwarded from Ethereum mainnet to MegaETH for the deposit
+            transaction to use, as well as adding extra data to the
+            transaction. As an example, the following
+            <code>cast send</code> command calls <code>depositETH</code>
+            to bridge 0.001 Ether with 61000 gas and extra data
+            <code>bunny</code>.</p>
+            <div class="sourceCode" id="cb1"><pre
+            class="sourceCode bash"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">cast</span> send 0x0CA3A2FBC3D770b578223FBB6b062fa875a2eE75 <span class="st">&#39;depositETH(uint32, bytes)&#39;</span> 61000 <span class="st">&quot;0x62756e6e79&quot;</span> <span class="at">--value</span> 0.001ether</span></code></pre></div>
+            <h2 id="contracts-of-potential-interest">Contracts of
+            Potential Interest</h2>
             <h3 id="on-megaeth-mainnet">On MegaETH Mainnet</h3>
             <table>
+            <colgroup>
+            <col style="width: 18%" />
+            <col style="width: 26%" />
+            <col style="width: 56%" />
+            </colgroup>
             <thead>
             <tr class="header">
             <th>Item</th>
@@ -156,8 +239,15 @@
             <!--
             | **High Resolution Timestamp** | `0x6342000000000000000000000000000000000002` | The function signature is `function timestamp() external view returns (uint256)` where the return value is timestamp in microseconds. |
             -->
-            <p>See OP Stack docs for a complete list of <a href="https://docs.optimism.io/op-stack/protocol/smart-contracts#layer-2-contracts-predeploys">predeployed</a> and <a href="https://docs.optimism.io/op-stack/features/preinstalls#contracts-and-deployed-addresses">preinstalled</a> contracts.</p>
-            <p>See the <a href="https://github.com/megaeth-labs/mega-tokenlist">mega-tokenlist</a> for a more comprehensive list of tokens in the ecosystem.</p>
+            <p>See OP Stack docs for a complete list of <a
+            href="https://docs.optimism.io/op-stack/protocol/smart-contracts#layer-2-contracts-predeploys">predeployed</a>
+            and <a
+            href="https://docs.optimism.io/op-stack/features/preinstalls#contracts-and-deployed-addresses">preinstalled</a>
+            contracts.</p>
+            <p>See the <a
+            href="https://github.com/megaeth-labs/mega-tokenlist">mega-tokenlist</a>
+            for a more comprehensive list of tokens in the
+            ecosystem.</p>
             <h3 id="on-ethereum-mainnet">On Ethereum Mainnet</h3>
             <table>
             <colgroup>
@@ -174,23 +264,23 @@
             </thead>
             <tbody>
             <tr class="odd">
+            <td>DisputeGameFactoryProxy</td>
+            <td><code>0x8546840adf796875cd9aacc5b3b048f6b2c9d563</code></td>
+            <td></td>
+            </tr>
+            <tr class="even">
             <td>L1CrossDomainMessengerProxy</td>
             <td><code>0x6C7198250087B29A8040eC63903Bc130f4831Cc9</code></td>
             <td></td>
             </tr>
-            <tr class="even">
+            <tr class="odd">
             <td>L1ERC721BridgeProxy</td>
             <td><code>0x3D8ee269F87A7f3F0590c5C0d825FFF06212A242</code></td>
             <td></td>
             </tr>
-            <tr class="odd">
+            <tr class="even">
             <td>L1StandardBridgeProxy</td>
             <td><code>0x0CA3A2FBC3D770b578223FBB6b062fa875a2eE75</code></td>
-            <td></td>
-            </tr>
-            <tr class="even">
-            <td>OptimismPortalProxy</td>
-            <td><code>0x7f82f57F0Dd546519324392e408b01fcC7D709e8</code></td>
             <td></td>
             </tr>
             <tr class="odd">
@@ -199,18 +289,37 @@
             <td></td>
             </tr>
             <tr class="even">
+            <td>OptimismPortalProxy</td>
+            <td><code>0x7f82f57F0Dd546519324392e408b01fcC7D709e8</code></td>
+            <td></td>
+            </tr>
+            <tr class="odd">
+            <td>ProtocolVersionsProxy</td>
+            <td><code>0x150355311f965af4937fcca526f9df0573fd5b85</code></td>
+            <td></td>
+            </tr>
+            <tr class="even">
+            <td>SuperchainConfigProxy</td>
+            <td><code>0x5d0ff601bc8580d8682c0462df55343cb0b99285</code></td>
+            <td></td>
+            </tr>
+            <tr class="odd">
             <td>SystemConfigProxy</td>
             <td><code>0x1ED92E1bc9A2735216540EDdD0191144681cb77E</code></td>
             <td></td>
             </tr>
-            <tr class="odd">
+            <tr class="even">
             <td>USDM</td>
             <td><code>0xEc2AF1C8B110a61fD9C3Fa6a554a031Ca9943926</code></td>
             <td></td>
             </tr>
             </tbody>
             </table>
-            <p>MegaETH’s smart contracts are from OP Stack’s <a href="https://github.com/ethereum-optimism/optimism/tree/backports/op-contracts/v3.0.0/packages/contracts-bedrock">op-contracts/v3.0.0 release</a>. See OP Stack docs for <a href="https://docs.optimism.io/op-stack/protocol/smart-contracts#l1-contract-details">descriptions of these contracts</a>.</p>
+            <p>MegaETH’s smart contracts are from OP Stack’s <a
+            href="https://github.com/ethereum-optimism/optimism/tree/backports/op-contracts/v3.0.0/packages/contracts-bedrock">op-contracts/v3.0.0
+            release</a>. See OP Stack docs for <a
+            href="https://docs.optimism.io/op-stack/protocol/smart-contracts#l1-contract-details">descriptions
+            of these contracts</a>.</p>
         </main>
 
         <footer class="site-footer">

--- a/public/index.html
+++ b/public/index.html
@@ -55,11 +55,16 @@
         <main class="site-content">
             <p>You have reached the user manual of MegaETH.</p>
             <ul>
-            <li><a href="/frontier">Mainnet</a>: instructions on connecting to and using MegaETH Mainnet</li>
-            <li><a href="/testnet">Testnet</a>: instructions on connecting to the testnet</li>
-            <li><a href="/megaevm">MegaEVM</a>: differences between MegaETH’s execution environment and vanilla EVM</li>
-            <li><a href="/realtime-api">Realtime API</a>: MegaETH’s performance-focused enhancements to Ethereum JSON-RPC</li>
-            <li><a href="/faucet">Faucet</a>: supply of free gas tokens for the testnet</li>
+            <li><a href="/frontier">Mainnet</a>: instructions on
+            connecting to and using MegaETH Mainnet</li>
+            <li><a href="/testnet">Testnet</a>: instructions on
+            connecting to the testnet</li>
+            <li><a href="/megaevm">MegaEVM</a>: differences between
+            MegaETH’s execution environment and vanilla EVM</li>
+            <li><a href="/realtime-api">Realtime API</a>: MegaETH’s
+            performance-focused enhancements to Ethereum JSON-RPC</li>
+            <li><a href="/faucet">Faucet</a>: supply of free gas tokens
+            for the testnet</li>
             </ul>
         </main>
 

--- a/public/megaevm.html
+++ b/public/megaevm.html
@@ -51,33 +51,67 @@
                 
                                 <nav id="TOC">
                     <ul>
-                    <li><a href="#overview">Overview</a>
+                    <li><a href="#overview"
+                    id="toc-overview">Overview</a>
                     <ul>
-                    <li><a href="#key-differences-at-a-glance">Key Differences at a Glance</a></li>
+                    <li><a href="#key-differences-at-a-glance"
+                    id="toc-key-differences-at-a-glance">Key Differences
+                    at a Glance</a></li>
                     </ul></li>
-                    <li><a href="#multidimensional-gas-model">Multidimensional Gas Model</a>
+                    <li><a href="#multidimensional-gas-model"
+                    id="toc-multidimensional-gas-model">Multidimensional
+                    Gas Model</a>
                     <ul>
-                    <li><a href="#compute-gas-costs">Compute Gas Costs</a></li>
-                    <li><a href="#storage-gas-costs">Storage Gas Costs</a></li>
-                    <li><a href="#bucket-multiplier">Bucket Multiplier</a></li>
-                    <li><a href="#tips-for-developers">Tips for Developers</a></li>
+                    <li><a href="#compute-gas-costs"
+                    id="toc-compute-gas-costs">Compute Gas
+                    Costs</a></li>
+                    <li><a href="#storage-gas-costs"
+                    id="toc-storage-gas-costs">Storage Gas
+                    Costs</a></li>
+                    <li><a href="#bucket-multiplier"
+                    id="toc-bucket-multiplier">Bucket
+                    Multiplier</a></li>
+                    <li><a href="#tips-for-developers"
+                    id="toc-tips-for-developers">Tips for
+                    Developers</a></li>
                     </ul></li>
-                    <li><a href="#multidimensional-resource-limits">Multidimensional Resource Limits</a>
+                    <li><a href="#multidimensional-resource-limits"
+                    id="toc-multidimensional-resource-limits">Multidimensional
+                    Resource Limits</a>
                     <ul>
-                    <li><a href="#definitions-of-resource-types">Definitions of Resource Types</a></li>
+                    <li><a href="#definitions-of-resource-types"
+                    id="toc-definitions-of-resource-types">Definitions
+                    of Resource Types</a></li>
                     </ul></li>
-                    <li><a href="#access-to-volatile-data">Access to Volatile Data</a>
+                    <li><a href="#access-to-volatile-data"
+                    id="toc-access-to-volatile-data">Access to Volatile
+                    Data</a>
                     <ul>
-                    <li><a href="#opcodes-for-access-the-block-environment">Opcodes for Access the Block Environment</a></li>
-                    <li><a href="#accessing-the-beneficiary-account">Accessing the Beneficiary Account</a></li>
-                    <li><a href="#accessing-the-native-oracle-interface">Accessing the Native Oracle Interface</a></li>
-                    <li><a href="#remarks">Remarks</a></li>
+                    <li><a
+                    href="#opcodes-for-access-the-block-environment"
+                    id="toc-opcodes-for-access-the-block-environment">Opcodes
+                    for Access the Block Environment</a></li>
+                    <li><a href="#accessing-the-beneficiary-account"
+                    id="toc-accessing-the-beneficiary-account">Accessing
+                    the Beneficiary Account</a></li>
+                    <li><a href="#accessing-the-native-oracle-interface"
+                    id="toc-accessing-the-native-oracle-interface">Accessing
+                    the Native Oracle Interface</a></li>
+                    <li><a href="#remarks"
+                    id="toc-remarks">Remarks</a></li>
                     </ul></li>
-                    <li><a href="#miscellaneous">Miscellaneous</a>
+                    <li><a href="#miscellaneous"
+                    id="toc-miscellaneous">Miscellaneous</a>
                     <ul>
-                    <li><a href="#increased-contract-size-limit">Increased Contract Size Limit</a></li>
-                    <li><a href="#selfdestruct-with-eip-6780-semantics"><code>SELFDESTRUCT</code> with EIP-6780 Semantics</a></li>
-                    <li><a href="#rule-for-gas-forwarding">“98/100” Rule for Gas Forwarding</a></li>
+                    <li><a href="#increased-contract-size-limit"
+                    id="toc-increased-contract-size-limit">Increased
+                    Contract Size Limit</a></li>
+                    <li><a href="#selfdestruct-with-eip-6780-semantics"
+                    id="toc-selfdestruct-with-eip-6780-semantics"><code>SELFDESTRUCT</code>
+                    with EIP-6780 Semantics</a></li>
+                    <li><a href="#rule-for-gas-forwarding"
+                    id="toc-rule-for-gas-forwarding">“98/100” Rule for
+                    Gas Forwarding</a></li>
                     </ul></li>
                     </ul>
                 </nav>
@@ -85,16 +119,38 @@
         </header>
 
         <main class="site-content">
-            <p><em>MegaEVM</em> is MegaETH’s execution environment. It is fully compatible with Ethereum smart contracts while introducing optimizations for the unique characteristics of MegaETH’s architecture.</p>
+            <p><em>MegaEVM</em> is MegaETH’s execution environment. It
+            is fully compatible with Ethereum smart contracts while
+            introducing optimizations for the unique characteristics of
+            MegaETH’s architecture.</p>
             <h2 id="overview">Overview</h2>
-            <p>MegaEVM builds on established standards. Its latest hardfork, <em>Rex3</em>, is based on <a href="https://specs.optimism.io/protocol/isthmus/overview.html">Optimism Isthmus</a>, which in turn is adapted from <a href="https://ethereum.org/roadmap/pectra/">Ethereum Prague</a>. This means:</p>
+            <p>MegaEVM builds on established standards. Its latest
+            hardfork, <em>Rex3</em>, is based on <a
+            href="https://specs.optimism.io/protocol/isthmus/overview.html">Optimism
+            Isthmus</a>, which in turn is adapted from <a
+            href="https://ethereum.org/roadmap/pectra/">Ethereum
+            Prague</a>. This means:</p>
             <ul>
             <li>All standard Solidity contracts work on MegaETH.</li>
-            <li>Standard development tools (Hardhat, Foundry, Remix, etc.) are compatible.</li>
+            <li>Standard development tools (Hardhat, Foundry, Remix,
+            etc.) are compatible.</li>
             <li>Existing Ethereum libraries and patterns apply.</li>
             </ul>
-            <p>Meanwhile, MegaEVM introduces a few changes to accommodate MegaETH’s low fees and high capacity. The most important change is the <em>multidimensional gas model and resource limits</em>. In MegaEVM, transactions consume two types of gas: <em>compute gas</em>, which models computation at large and is identically defined as Ethereum’s gas; and <em>storage gas</em>, a new concept that models the storage subsystem in particular. Similarly, MegaEVM caps resource usage of transactions and blocks using rules that each targets an individual type of resource. Developers should consider these changes in contrast to Ethereum’s EVM, where gas is the singular metric for metering and limiting resource consumption.</p>
-            <h3 id="key-differences-at-a-glance">Key Differences at a Glance</h3>
+            <p>Meanwhile, MegaEVM introduces a few changes to
+            accommodate MegaETH’s low fees and high capacity. The most
+            important change is the <em>multidimensional gas model and
+            resource limits</em>. In MegaEVM, transactions consume two
+            types of gas: <em>compute gas</em>, which models computation
+            at large and is identically defined as Ethereum’s gas; and
+            <em>storage gas</em>, a new concept that models the storage
+            subsystem in particular. Similarly, MegaEVM caps resource
+            usage of transactions and blocks using rules that each
+            targets an individual type of resource. Developers should
+            consider these changes in contrast to Ethereum’s EVM, where
+            gas is the singular metric for metering and limiting
+            resource consumption.</p>
+            <h3 id="key-differences-at-a-glance">Key Differences at a
+            Glance</h3>
             <table>
             <colgroup>
             <col style="width: 12%" />
@@ -127,25 +183,29 @@
             <td>Gas forwarding rule</td>
             <td>63/64</td>
             <td><strong>98/100</strong></td>
-            <td>As defined in <a href="https://eips.ethereum.org/EIPS/eip-150">EIP-150</a>.</td>
+            <td>As defined in <a
+            href="https://eips.ethereum.org/EIPS/eip-150">EIP-150</a>.</td>
             </tr>
             <tr class="even">
             <td><code>SELFDESTRUCT</code></td>
             <td>Deprecated</td>
             <td><strong>EIP-6780 semantics</strong></td>
-            <td>Active only within the creating transaction, per <a href="https://eips.ethereum.org/EIPS/eip-6780">EIP-6780</a>.</td>
+            <td>Active only within the creating transaction, per <a
+            href="https://eips.ethereum.org/EIPS/eip-6780">EIP-6780</a>.</td>
             </tr>
             <tr class="odd">
             <td>Gas model</td>
             <td>Unidimensional</td>
             <td><strong>Multidimensional</strong></td>
-            <td>Compute gas and storage gas. Compute gas is identical to Ethereum’s gas.</td>
+            <td>Compute gas and storage gas. Compute gas is identical to
+            Ethereum’s gas.</td>
             </tr>
             <tr class="even">
             <td>Resource limits</td>
             <td>Unidimensional</td>
             <td><strong>Multidimensional</strong></td>
-            <td>4 limits in addition to total gas limit specified by sender.</td>
+            <td>4 limits in addition to total gas limit specified by
+            sender.</td>
             </tr>
             <tr class="odd">
             <td>Base intrinsic gas</td>
@@ -155,18 +215,36 @@
             </tr>
             </tbody>
             </table>
-            <h2 id="multidimensional-gas-model">Multidimensional Gas Model</h2>
-            <p>MegaETH uses a <em>multidimensional gas model</em> that separates gas costs into two categories:</p>
+            <h2 id="multidimensional-gas-model">Multidimensional Gas
+            Model</h2>
+            <p>MegaETH uses a <em>multidimensional gas model</em> that
+            separates gas costs into two categories:</p>
             <ul>
-            <li><strong>Compute Gas</strong>: Standard execution costs as defined in Ethereum’s EVM</li>
-            <li><strong>Storage Gas</strong>: Additional costs for operations that create persistent data</li>
+            <li><strong>Compute Gas</strong>: Standard execution costs
+            as defined in Ethereum’s EVM</li>
+            <li><strong>Storage Gas</strong>: Additional costs for
+            operations that create persistent data</li>
             </ul>
-            <p>The total gas of a transaction is the sum of its compute gas and storage gas.</p>
+            <p>The total gas of a transaction is the sum of its compute
+            gas and storage gas.</p>
             <h3 id="compute-gas-costs">Compute Gas Costs</h3>
-            <p>For any operation, its compute gas cost in MegaEVM is equal to its gas cost in standard EVM. For example, updating a cold storage slot from zero to nonzero costs 22,100 gas in standard EVM, so the compute gas cost of the said operation in MegaEVM is also 22,100. As another example, every transaction incurs an intrinsic gas cost of 21,000 in standard EVM, so every transaction also incurs an intrinsic compute gas cost of 21,000 in MegaEVM.</p>
-            <p>As a rule of thumb, the amount of compute gas a transaction burns is equal to the amount of gas it would burn in Ethereum’s EVM.</p>
+            <p>For any operation, its compute gas cost in MegaEVM is
+            equal to its gas cost in standard EVM. For example, updating
+            a cold storage slot from zero to nonzero costs 22,100 gas in
+            standard EVM, so the compute gas cost of the said operation
+            in MegaEVM is also 22,100. As another example, every
+            transaction incurs an intrinsic gas cost of 21,000 in
+            standard EVM, so every transaction also incurs an intrinsic
+            compute gas cost of 21,000 in MegaEVM.</p>
+            <p>As a rule of thumb, the amount of compute gas a
+            transaction burns is equal to the amount of gas it would
+            burn in Ethereum’s EVM.</p>
             <h3 id="storage-gas-costs">Storage Gas Costs</h3>
-            <p>The storage gas cost of most operations is zero. The following table lists all operations where storage gas does apply. Some storage gas calculations involve a parameter called <em>bucket multiplier</em> (denoted as m). The next section explains this concept.</p>
+            <p>The storage gas cost of most operations is zero. The
+            following table lists all operations where storage gas does
+            apply. Some storage gas calculations involve a parameter
+            called <em>bucket multiplier</em> (denoted as m). The next
+            section explains this concept.</p>
             <table>
             <colgroup>
             <col style="width: 13%" />
@@ -184,7 +262,9 @@
             <tr class="odd">
             <td>Intrinsic</td>
             <td>39,000</td>
-            <td>Incurred by every transaction. Combined with the intrinsic compute gas cost of 21,000, the total intrinsic gas cost of a transaction is 60,000.</td>
+            <td>Incurred by every transaction. Combined with the
+            intrinsic compute gas cost of 21,000, the total intrinsic
+            gas cost of a transaction is 60,000.</td>
             </tr>
             <tr class="even">
             <td>Zero-to-nonzero <code>SSTORE</code></td>
@@ -199,7 +279,8 @@
             <tr class="even">
             <td>Contract creation</td>
             <td>32,000 × (m-1)</td>
-            <td><code>CREATE</code>/<code>CREATE2</code> operations.</td>
+            <td><code>CREATE</code>/<code>CREATE2</code>
+            operations.</td>
             </tr>
             <tr class="odd">
             <td>Code deposit</td>
@@ -229,29 +310,52 @@
             <tr class="even">
             <td>EIP-7623 floor (zero)</td>
             <td>100/byte</td>
-            <td><a href="https://eips.ethereum.org/EIPS/eip-7623">EIP-7623</a> floor cost per zero byte in transaction input.</td>
+            <td><a
+            href="https://eips.ethereum.org/EIPS/eip-7623">EIP-7623</a>
+            floor cost per zero byte in transaction input.</td>
             </tr>
             <tr class="odd">
             <td>EIP-7623 floor (nonzero)</td>
             <td>400/byte</td>
-            <td><a href="https://eips.ethereum.org/EIPS/eip-7623">EIP-7623</a> floor cost per nonzero byte in transaction input.</td>
+            <td><a
+            href="https://eips.ethereum.org/EIPS/eip-7623">EIP-7623</a>
+            floor cost per nonzero byte in transaction input.</td>
             </tr>
             </tbody>
             </table>
-            <p>All other operations not mentioned in the previous table incurs no storage gas cost.</p>
+            <p>All other operations not mentioned in the previous table
+            incurs no storage gas cost.</p>
             <h3 id="bucket-multiplier">Bucket Multiplier</h3>
-            <p>Accounts and their storage slots are stored in segments of MegaETH’s SALT state trie called “buckets”. Buckets grow in size and capacity as they hold more data. The cost of writing new data to a bucket (creating new accounts or changing storage slots from zero to nonzero) varies based on its capacity, and such variation is reflected in storage gas costs of these operations in the form of the <em>bucket multiplier</em> (denoted as m).</p>
-            <p>The bucket multiplier of a bucket is simply defined as the ratio of its capacity and the minimum capacity of buckets. The latter is a system parameter. In other words,</p>
+            <p>Accounts and their storage slots are stored in segments
+            of MegaETH’s SALT state trie called “buckets”. Buckets grow
+            in size and capacity as they hold more data. The cost of
+            writing new data to a bucket (creating new accounts or
+            changing storage slots from zero to nonzero) varies based on
+            its capacity, and such variation is reflected in storage gas
+            costs of these operations in the form of the <em>bucket
+            multiplier</em> (denoted as m).</p>
+            <p>The bucket multiplier of a bucket is simply defined as
+            the ratio of its capacity and the minimum capacity of
+            buckets. The latter is a system parameter. In other
+            words,</p>
             <pre><code>Bucket Multiplier = Bucket Capacity / MIN_BUCKET_CAP.</code></pre>
-            <p>SALT’s design ensures that bucket multiplier is always an integer.</p>
-            <p>Without diving into details of SALT, here are a few rules of thumb for developers.</p>
+            <p>SALT’s design ensures that bucket multiplier is always an
+            integer.</p>
+            <p>Without diving into details of SALT, here are a few rules
+            of thumb for developers.</p>
             <ul>
-            <li>Unless a bucket has expanded to handle heavy storage needs, bucket multiplier is typically 1.</li>
-            <li>When bucket multiplier is 1, <code>SSTORE</code>, account creation, and contract creation incurs zero storage gas cost.</li>
-            <li>Bucket expand as they fill up; the multiplier increases and storage gas costs rise.</li>
-            <li>Developers typically do not need to consider bucket multiplier when designing contracts.</li>
+            <li>Unless a bucket has expanded to handle heavy storage
+            needs, bucket multiplier is typically 1.</li>
+            <li>When bucket multiplier is 1, <code>SSTORE</code>,
+            account creation, and contract creation incurs zero storage
+            gas cost.</li>
+            <li>Bucket expand as they fill up; the multiplier increases
+            and storage gas costs rise.</li>
+            <li>Developers typically do not need to consider bucket
+            multiplier when designing contracts.</li>
             </ul>
-            <p>Below are a few examples of storage gas costs at different bucket multiplier values.</p>
+            <p>Below are a few examples of storage gas costs at
+            different bucket multiplier values.</p>
             <table>
             <thead>
             <tr class="header">
@@ -284,22 +388,54 @@
             </table>
             <h3 id="tips-for-developers">Tips for Developers</h3>
             <ul>
-            <li><strong>Use MegaETH’s native gas estimation APIs.</strong> Tools not explicitly modified for MegaEVM do not account for storage gas and will report overly small numbers.
+            <li><strong>Use MegaETH’s native gas estimation
+            APIs.</strong> Tools not explicitly modified for MegaEVM do
+            not account for storage gas and will report overly small
+            numbers.
             <ul>
-            <li>For example, when running <code>forge script</code>, use <code>--skip-simulation</code> to avoid its built-in EVM and use <code>--gas-limit</code> to manually specify a sufficiently high gas limit.</li>
+            <li>For example, when running <code>forge script</code>, use
+            <code>--skip-simulation</code> to avoid its built-in EVM and
+            use <code>--gas-limit</code> to manually specify a
+            sufficiently high gas limit.</li>
             </ul></li>
-            <li><strong>Account for storage gas.</strong> An Ether transfer costs 60,000 gas (21,000 compute gas plus 39,000 storage gas). This is the minimum gas cost (intrinsic gas) for any transaction.
+            <li><strong>Account for storage gas.</strong> An Ether
+            transfer costs 60,000 gas (21,000 compute gas plus 39,000
+            storage gas). This is the minimum gas cost (intrinsic gas)
+            for any transaction.
             <ul>
-            <li>The RPC returns “intrinsic gas too low” when transaction gas limit is smaller than 60,000.</li>
+            <li>The RPC returns “intrinsic gas too low” when transaction
+            gas limit is smaller than 60,000.</li>
             </ul></li>
-            <li><strong>Prefer transient storage or memory over persistent storage.</strong> Allocating new storage slots costs storage gas and counts towards various resource limits (explained in the next section). Use transient storage (<a href="https://eips.ethereum.org/EIPS/eip-1153">EIP-1153</a> <code>TSTORE</code>/<code>TLOAD</code>) for data that only needs to persist within a transaction, or memory for data within a single call. This avoids storage gas costs entirely and ensures calling transactions stay within resource limits.</li>
-            <li><strong>Reuse storage slots.</strong> Storage gas applies when changing a slot from zero to nonzero and does not apply when overwriting a slot that is already nonzero. When a slot can be freed (i.e., changed to zero) but is expected to be allocated again (i.e., changed to nonzero) very soon, consider keeping the slot at nonzero so that no storage gas is charged the next time it is used.
+            <li><strong>Prefer transient storage or memory over
+            persistent storage.</strong> Allocating new storage slots
+            costs storage gas and counts towards various resource limits
+            (explained in the next section). Use transient storage (<a
+            href="https://eips.ethereum.org/EIPS/eip-1153">EIP-1153</a>
+            <code>TSTORE</code>/<code>TLOAD</code>) for data that only
+            needs to persist within a transaction, or memory for data
+            within a single call. This avoids storage gas costs entirely
+            and ensures calling transactions stay within resource
+            limits.</li>
+            <li><strong>Reuse storage slots.</strong> Storage gas
+            applies when changing a slot from zero to nonzero and does
+            not apply when overwriting a slot that is already nonzero.
+            When a slot can be freed (i.e., changed to zero) but is
+            expected to be allocated again (i.e., changed to nonzero)
+            very soon, consider keeping the slot at nonzero so that no
+            storage gas is charged the next time it is used.
             <ul>
-            <li>As a rule of thumb, avoid design patterns that allocate a lot of slots only to free them soon after.</li>
+            <li>As a rule of thumb, avoid design patterns that allocate
+            a lot of slots only to free them soon after.</li>
             </ul></li>
             </ul>
-            <h2 id="multidimensional-resource-limits">Multidimensional Resource Limits</h2>
-            <p>In addition to limits already defined in standard EVM, MegaEVM enforces four additional limits on how much resources each transaction or block may consume. The following table is an overview. The next few sections explain what counts towards each type of resource and the respective limit.</p>
+            <h2 id="multidimensional-resource-limits">Multidimensional
+            Resource Limits</h2>
+            <p>In addition to limits already defined in standard EVM,
+            MegaEVM enforces four additional limits on how much
+            resources each transaction or block may consume. The
+            following table is an overview. The next few sections
+            explain what counts towards each type of resource and the
+            respective limit.</p>
             <table>
             <thead>
             <tr class="header">
@@ -331,25 +467,43 @@
             </tr>
             </tbody>
             </table>
-            <p>When a transaction hits <em>any</em> of the aforementioned per-transaction limits, the following happens:</p>
+            <p>When a transaction hits <em>any</em> of the
+            aforementioned per-transaction limits, the following
+            happens:</p>
             <ol type="1">
             <li>Execution halts immediately.</li>
-            <li>Any remaining gas is preserved and refunded to sender.</li>
-            <li>Transaction is included in the block with status set to failed (status=0).</li>
+            <li>Any remaining gas is preserved and refunded to
+            sender.</li>
+            <li>Transaction is included in the block with status set to
+            failed (status=0).</li>
             <li>No state changes from the transaction are applied.</li>
             </ol>
-            <p>If any of the aforementioned per-block limits is hit when building a block, the following happens:</p>
+            <p>If any of the aforementioned per-block limits is hit when
+            building a block, the following happens:</p>
             <ol type="1">
-            <li>The transaction that caused the block to go over limits is allowed to execute to completion and will be included in the block. Per-transaction limits still apply.</li>
-            <li>No more transaction will be executed or added to this block.</li>
+            <li>The transaction that caused the block to go over limits
+            is allowed to execute to completion and will be included in
+            the block. Per-transaction limits still apply.</li>
+            <li>No more transaction will be executed or added to this
+            block.</li>
             </ol>
-            <h3 id="definitions-of-resource-types">Definitions of Resource Types</h3>
-            <p>For all resource types, the usage incurred by a block is simply the sum of the usage incurred by each transaction in the block. For example, if a block contains two transactions, one using 300 KV updates and the other using 400 KV updates, then the block uses 700 KV updates.</p>
-            <p>The usage incurred by an individual transaction is defined as following.</p>
+            <h3 id="definitions-of-resource-types">Definitions of
+            Resource Types</h3>
+            <p>For all resource types, the usage incurred by a block is
+            simply the sum of the usage incurred by each transaction in
+            the block. For example, if a block contains two
+            transactions, one using 300 KV updates and the other using
+            400 KV updates, then the block uses 700 KV updates.</p>
+            <p>The usage incurred by an individual transaction is
+            defined as following.</p>
             <h4 id="compute-gas">Compute Gas</h4>
-            <p>Compute gas cost of a transaction as defined in previous sections.</p>
+            <p>Compute gas cost of a transaction as defined in previous
+            sections.</p>
             <h4 id="data-size">Data Size</h4>
-            <p>Data size measures the amount of data that needs to be transmitted and stored for each transaction. Both the transaction itself and its execution results are considered. It is the total size of the following items:</p>
+            <p>Data size measures the amount of data that needs to be
+            transmitted and stored for each transaction. Both the
+            transaction itself and its execution results are considered.
+            It is the total size of the following items:</p>
             <ul>
             <li>Transaction calldata</li>
             <li>Event logs (topics and data)</li>
@@ -358,15 +512,48 @@
             <li>Deployed contract code</li>
             </ul>
             <h4 id="kv-updates">KV Updates</h4>
-            <p>KV updates measure the total number of state entries (accounts and storage slots) updated by a transaction. Each update to a storage slot or an account counts as one update towards the limit. Repeated updates to the same storage slot or account counts as only one update.</p>
+            <p>KV updates measure the total number of state entries
+            (accounts and storage slots) updated by a transaction. Each
+            update to a storage slot or an account counts as one update
+            towards the limit. Repeated updates to the same storage slot
+            or account counts as only one update.</p>
             <h4 id="state-growth">State Growth</h4>
-            <p>State growth measures the number of new state entries (accounts and storage slots) created by a transaction. Each new storage slot (created by a zero-to-nonzero <code>SSTORE</code>), account, or contract counts as one unit towards the limit. If a newly created storage slot or account is cleared before the transaction ends, thus occupying no storage space permanently, it does not count towards the limit.</p>
-            <h2 id="access-to-volatile-data">Access to Volatile Data</h2>
-            <p>MegaEVM provides APIs for transactions to access <em>volatile data</em>, or data that changes frequently and thus expires quickly after being accessed. This includes metadata of the current block such as the block number, states of the block beneficiary, as well as data available through the native oracle interface (see below).</p>
-            <p>When a transaction accesses volatile data, dependency forms between the transaction and other transactions or operations that attempt to update the data. Such dependency harms performance. For example, if a transaction reads the current block number using the <code>NUMBER</code> opcode, the sequencer cannot start a new block until the transaction finishes and gets included in the current block, as doing so would cause the block number to change and invalidate the value previously read by the transaction. If the transaction takes long to finish, block production would be blocked (no pun intended), which impacts latency.</p>
-            <p>MegaEVM mitigates this issue by limiting the amount of compute gas a transaction may use <em>after it accesses volatile data</em>. This ensures transactions that access volatile data yield quickly. In the following subsections, we detail the limits.</p>
-            <h3 id="opcodes-for-access-the-block-environment">Opcodes for Access the Block Environment</h3>
-            <p>Accessing these opcodes caps the transaction’s global compute gas to 20,000,000.</p>
+            <p>State growth measures the number of new state entries
+            (accounts and storage slots) created by a transaction. Each
+            new storage slot (created by a zero-to-nonzero
+            <code>SSTORE</code>), account, or contract counts as one
+            unit towards the limit. If a newly created storage slot or
+            account is cleared before the transaction ends, thus
+            occupying no storage space permanently, it does not count
+            towards the limit.</p>
+            <h2 id="access-to-volatile-data">Access to Volatile
+            Data</h2>
+            <p>MegaEVM provides APIs for transactions to access
+            <em>volatile data</em>, or data that changes frequently and
+            thus expires quickly after being accessed. This includes
+            metadata of the current block such as the block number,
+            states of the block beneficiary, as well as data available
+            through the native oracle interface (see below).</p>
+            <p>When a transaction accesses volatile data, dependency
+            forms between the transaction and other transactions or
+            operations that attempt to update the data. Such dependency
+            harms performance. For example, if a transaction reads the
+            current block number using the <code>NUMBER</code> opcode,
+            the sequencer cannot start a new block until the transaction
+            finishes and gets included in the current block, as doing so
+            would cause the block number to change and invalidate the
+            value previously read by the transaction. If the transaction
+            takes long to finish, block production would be blocked (no
+            pun intended), which impacts latency.</p>
+            <p>MegaEVM mitigates this issue by limiting the amount of
+            compute gas a transaction may use <em>after it accesses
+            volatile data</em>. This ensures transactions that access
+            volatile data yield quickly. In the following subsections,
+            we detail the limits.</p>
+            <h3 id="opcodes-for-access-the-block-environment">Opcodes
+            for Access the Block Environment</h3>
+            <p>Accessing these opcodes caps the transaction’s global
+            compute gas to 20,000,000.</p>
             <table>
             <thead>
             <tr class="header">
@@ -417,9 +604,15 @@
             </tr>
             </tbody>
             </table>
-            <h3 id="accessing-the-beneficiary-account">Accessing the Beneficiary Account</h3>
-            <p>Accessing the block beneficiary (coinbase) account also caps the transaction’s global compute gas to 20,000,000.</p>
+            <h3 id="accessing-the-beneficiary-account">Accessing the
+            Beneficiary Account</h3>
+            <p>Accessing the block beneficiary (coinbase) account also
+            caps the transaction’s global compute gas to 20,000,000.</p>
             <table>
+            <colgroup>
+            <col style="width: 52%" />
+            <col style="width: 47%" />
+            </colgroup>
             <thead>
             <tr class="header">
             <th>Trigger</th>
@@ -432,7 +625,8 @@
             <td>Reading beneficiary’s balance</td>
             </tr>
             <tr class="even">
-            <td><code>EXTCODECOPY</code>, <code>EXTCODESIZE</code>, <code>EXTCODEHASH</code></td>
+            <td><code>EXTCODECOPY</code>, <code>EXTCODESIZE</code>,
+            <code>EXTCODEHASH</code></td>
             <td>Accessing beneficiary’s code</td>
             </tr>
             <tr class="odd">
@@ -449,45 +643,71 @@
             </tr>
             </tbody>
             </table>
-            <h3 id="accessing-the-native-oracle-interface">Accessing the Native Oracle Interface</h3>
-            <p>Reading oracle data via <code>SLOAD</code> from the oracle contract storage caps the transaction’s global compute gas to 20,000,000. This is the same limit as accessing the block environment.</p>
+            <h3 id="accessing-the-native-oracle-interface">Accessing the
+            Native Oracle Interface</h3>
+            <p>Reading oracle data via <code>SLOAD</code> from the
+            oracle contract storage caps the transaction’s global
+            compute gas to 20,000,000. This is the same limit as
+            accessing the block environment.</p>
             <ul>
-            <li>Oracle contract address: <code>0x6342000000000000000000000000000000000001</code></li>
-            <li>Triggered by: <code>SLOAD</code> from oracle contract storage</li>
-            <li><code>DELEGATECALL</code> to the oracle contract does <strong>not</strong> trigger this limit</li>
+            <li>Oracle contract address:
+            <code>0x6342000000000000000000000000000000000001</code></li>
+            <li>Triggered by: <code>SLOAD</code> from oracle contract
+            storage</li>
+            <li><code>DELEGATECALL</code> to the oracle contract does
+            <strong>not</strong> trigger this limit</li>
             </ul>
             <h3 id="remarks">Remarks</h3>
-            <p>When multiple types of volatile data are accessed in the same transaction, the most restrictive limit applies. All volatile data sources currently share the same 20,000,000 compute gas cap.</p>
-            <p>Note that the further restricted compute gas limit is enforced on the compute gas consumption across the entire transaction execution. That is, if the transaction has already consumed more than 20M compute gas before accessing volatile data (e.g., from an oracle contract or the block environment), the transaction execution will halt immediately. Therefore, developers should avoid accessing volatile data in a transaction performing heavy computation. The following is a counterexample.</p>
+            <p>When multiple types of volatile data are accessed in the
+            same transaction, the most restrictive limit applies. All
+            volatile data sources currently share the same 20,000,000
+            compute gas cap.</p>
+            <p>Note that the further restricted compute gas limit is
+            enforced on the compute gas consumption across the entire
+            transaction execution. That is, if the transaction has
+            already consumed more than 20M compute gas before accessing
+            volatile data (e.g., from an oracle contract or the block
+            environment), the transaction execution will halt
+            immediately. Therefore, developers should avoid accessing
+            volatile data in a transaction performing heavy computation.
+            The following is a counterexample.</p>
             <pre class="solidity"><code>// Bad: Heavy computation after reading timestamp
-            function processWithTimestamp() external {
-                uint256 currentTime = block.timestamp; // Triggers 20M gas cap
-                // This loop might run out of gas!
-                for (uint i = 0; i &lt; 10000; i++) {
-                    heavyComputation(i, currentTime);
-                }
-            }
+function processWithTimestamp() external {
+    uint256 currentTime = block.timestamp; // Triggers 20M gas cap
+    // This loop might run out of gas!
+    for (uint i = 0; i &lt; 10000; i++) {
+        heavyComputation(i, currentTime);
+    }
+}
 
-            # System Contracts &amp; the Native Oracle Service
+# System Contracts &amp; the Native Oracle Service
 
-            MegaEVM provides a native oracle interface that provides realtime access to
-            data from off-chain sources.
+MegaEVM provides a native oracle interface that provides realtime access to
+data from off-chain sources.
 
-            ## High-Precision Timestamp Oracle
+## High-Precision Timestamp Oracle
 
-            This oracle provides timestamps at microsecond resolution. Developers might
-            find it useful if `block.timestamp` is not granular enough.
+This oracle provides timestamps at microsecond resolution. Developers might
+find it useful if `block.timestamp` is not granular enough.
 
-            **Address:** `0x6342000000000000000000000000000000000002`
+**Address:** `0x6342000000000000000000000000000000000002`
 
-            **Interface:**
+**Interface:**
 
-            ```solidity
-            interface HighPrecisionTimestampOracle {
-                function timestamp() external view returns (uint256);
-            }</code></pre>
-            <p>Note that data for this oracle is supplied solely by the sequencer based on its local clock. This implies that the sequencer must be trusted to publish accurate data. Avoid using this oracle if such trust assumption is too strong for your use case.</p>
-            <p>This oracle internally reads the core oracle contract <code>0x6342000000000000000000000000000000000001</code>. Hence, obtaining high-precision timestamps accesses volatile data and is subject to the compute gas limits detailed in the previous section.</p>
+```solidity
+interface HighPrecisionTimestampOracle {
+    function timestamp() external view returns (uint256);
+}</code></pre>
+            <p>Note that data for this oracle is supplied solely by the
+            sequencer based on its local clock. This implies that the
+            sequencer must be trusted to publish accurate data. Avoid
+            using this oracle if such trust assumption is too strong for
+            your use case.</p>
+            <p>This oracle internally reads the core oracle contract
+            <code>0x6342000000000000000000000000000000000001</code>.
+            Hence, obtaining high-precision timestamps accesses volatile
+            data and is subject to the compute gas limits detailed in
+            the previous section.</p>
             <!-- next time
 
             # Precompiles
@@ -507,12 +727,25 @@
             - Uses EIP-7883 pricing
             -->
             <h2 id="miscellaneous">Miscellaneous</h2>
-            <h3 id="increased-contract-size-limit">Increased Contract Size Limit</h3>
-            <p>MegaETH supports contracts up to 512 KB in size. This is increased from 24 KB in Ethereum.</p>
-            <h3 id="selfdestruct-with-eip-6780-semantics"><code>SELFDESTRUCT</code> with EIP-6780 Semantics</h3>
-            <p>The <code>SELFDESTRUCT</code> opcode follows <a href="https://eips.ethereum.org/EIPS/eip-6780">EIP-6780</a> semantics. It only destroys a contract when called within the same transaction that created the contract. In all other cases, <code>SELFDESTRUCT</code> behaves as a simple Ether transfer without destroying the contract or clearing its storage.</p>
-            <h3 id="rule-for-gas-forwarding">“98/100” Rule for Gas Forwarding</h3>
-            <p>MegaETH allows a caller to forward at most 98/100 of remaining gas to callee. The parameter is 63/64 in Ethereum.</p>
+            <h3 id="increased-contract-size-limit">Increased Contract
+            Size Limit</h3>
+            <p>MegaETH supports contracts up to 512 KB in size. This is
+            increased from 24 KB in Ethereum.</p>
+            <h3
+            id="selfdestruct-with-eip-6780-semantics"><code>SELFDESTRUCT</code>
+            with EIP-6780 Semantics</h3>
+            <p>The <code>SELFDESTRUCT</code> opcode follows <a
+            href="https://eips.ethereum.org/EIPS/eip-6780">EIP-6780</a>
+            semantics. It only destroys a contract when called within
+            the same transaction that created the contract. In all other
+            cases, <code>SELFDESTRUCT</code> behaves as a simple Ether
+            transfer without destroying the contract or clearing its
+            storage.</p>
+            <h3 id="rule-for-gas-forwarding">“98/100” Rule for Gas
+            Forwarding</h3>
+            <p>MegaETH allows a caller to forward at most 98/100 of
+            remaining gas to callee. The parameter is 63/64 in
+            Ethereum.</p>
         </main>
 
         <footer class="site-footer">

--- a/public/miniblocks.html
+++ b/public/miniblocks.html
@@ -51,40 +51,94 @@
                 
                                 <nav id="TOC">
                     <ul>
-                    <li><a href="#motivation">Motivation</a></li>
-                    <li><a href="#properties-of-mini-blocks">Properties of Mini Blocks</a></li>
+                    <li><a href="#motivation"
+                    id="toc-motivation">Motivation</a></li>
+                    <li><a href="#properties-of-mini-blocks"
+                    id="toc-properties-of-mini-blocks">Properties of
+                    Mini Blocks</a></li>
                     </ul>
                 </nav>
                             </div>
         </header>
 
         <main class="site-content">
-            <p>MegaETH has two types of blocks: mini blocks and EVM blocks. EVM blocks are identical to their counterparts in other EVM chains, ensuring compatibility with existing tools and applications. Mini blocks are specific to MegaETH and anchor an ecosystem of applications, tools, and infrastructure propose-built for minimum end-to-end latency.</p>
+            <p>MegaETH has two types of blocks: mini blocks and EVM
+            blocks. EVM blocks are identical to their counterparts in
+            other EVM chains, ensuring compatibility with existing tools
+            and applications. Mini blocks are specific to MegaETH and
+            anchor an ecosystem of applications, tools, and
+            infrastructure propose-built for minimum end-to-end
+            latency.</p>
             <h2 id="motivation">Motivation</h2>
-            <p>Handling blocks at 10 millisecond intervals requires a significant amount of resources. While software optimizations and powerful hardware give the sequencer ample headroom to produce 100 blocks per second, pushing the data to other nodes, especially ones with limited connectivity, quickly becomes a bottleneck.</p>
-            <p>The key issue with standard EVM blocks is that their headers take up quite some space—more than 500 bytes per block. At 100 blocks per second, this translates to 1.57 TB of data per year just for the headers, a significant burden for lightweight setups.</p>
-            <p>Besides the resource overhead, the standard EVM block header is designed for chains whose block times are seconds or higher as well as light clients who use block headers as the sole root of trust. For example, timestamps have one second resolution, and the multiple Merkle roots optimize for succinctness of Merkle proofs rather than compactness of the headers. We believe that interactions with a chain in realtime—at tens of milliseconds of latency—will take on a different paradigm, and it is the right opportunity to redesign blocks for compactness and low latency.</p>
-            <h2 id="properties-of-mini-blocks">Properties of Mini Blocks</h2>
-            <p>Mini blocks share a lot of similarities with EVM blocks. Like EVM blocks,</p>
+            <p>Handling blocks at 10 millisecond intervals requires a
+            significant amount of resources. While software
+            optimizations and powerful hardware give the sequencer ample
+            headroom to produce 100 blocks per second, pushing the data
+            to other nodes, especially ones with limited connectivity,
+            quickly becomes a bottleneck.</p>
+            <p>The key issue with standard EVM blocks is that their
+            headers take up quite some space—more than 500 bytes per
+            block. At 100 blocks per second, this translates to 1.57 TB
+            of data per year just for the headers, a significant burden
+            for lightweight setups.</p>
+            <p>Besides the resource overhead, the standard EVM block
+            header is designed for chains whose block times are seconds
+            or higher as well as light clients who use block headers as
+            the sole root of trust. For example, timestamps have one
+            second resolution, and the multiple Merkle roots optimize
+            for succinctness of Merkle proofs rather than compactness of
+            the headers. We believe that interactions with a chain in
+            realtime—at tens of milliseconds of latency—will take on a
+            different paradigm, and it is the right opportunity to
+            redesign blocks for compactness and low latency.</p>
+            <h2 id="properties-of-mini-blocks">Properties of Mini
+            Blocks</h2>
+            <p>Mini blocks share a lot of similarities with EVM blocks.
+            Like EVM blocks,</p>
             <ul>
-            <li>Mini blocks are ordered lists of transactions executed and preconfirmed by the sequencer.</li>
-            <li>Mini blocks contain every transaction that has been processed by the system. That is, every transaction appears in one mini block and one EVM block.</li>
-            <li>Mini blocks are totally ordered by their block height, starting with 0 at the genesis.</li>
-            <li>Preconfirmation of mini blocks by the sequencer has the same level of guarantees as EVM blocks.</li>
+            <li>Mini blocks are ordered lists of transactions executed
+            and preconfirmed by the sequencer.</li>
+            <li>Mini blocks contain every transaction that has been
+            processed by the system. That is, every transaction appears
+            in one mini block and one EVM block.</li>
+            <li>Mini blocks are totally ordered by their block height,
+            starting with 0 at the genesis.</li>
+            <li>Preconfirmation of mini blocks by the sequencer has the
+            same level of guarantees as EVM blocks.</li>
             </ul>
             <p>On the other hand, there are some key differences</p>
             <ul>
-            <li>Mini blocks contain a different set of metadata fields compared to EVM blocks.</li>
-            <li>To make effective use of mini blocks, such as retrieving mini blocks with minimum latency, applications should use the <a href="/realtime-api">Realtime API</a>—MegaETH’s extension to the standard Ethereum JSON-RPC API.</li>
+            <li>Mini blocks contain a different set of metadata fields
+            compared to EVM blocks.</li>
+            <li>To make effective use of mini blocks, such as retrieving
+            mini blocks with minimum latency, applications should use
+            the <a href="/realtime-api">Realtime API</a>—MegaETH’s
+            extension to the standard Ethereum JSON-RPC API.</li>
             </ul>
-            <p>Transactions in a mini block never span multiple EVM blocks. In other words, for every mini block, the transactions it contains all appear in the same EVM block. Naturally, this establishes a mapping between mini blocks and EVM blocks; we say a mini block is <em>included</em> in an EVM block if the former contains transactions that appear in the latter.</p>
-            <p>MegaETH produces an EVM block roughly every second and a mini block roughly every 10 milliseconds. This implies a rough 1-to-100 ratio between the number of EVM blocks and the number of mini blocks. However, there is no guarantee on the number of mini blocks included in an EVM block. To get the precise number, developers should use the <code>miniBlockCount</code> field in the responses when calling <code>eth_subscribe</code> to subscribe to <code>newHeads</code>. This is an example of the responses:</p>
-            <div class="sourceCode" id="cb1"><pre class="sourceCode json"><code class="sourceCode json"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true"></a><span class="fu">{</span></span>
-            <span id="cb1-2"><a href="#cb1-2" aria-hidden="true"></a>  <span class="er">...</span></span>
-            <span id="cb1-3"><a href="#cb1-3" aria-hidden="true"></a>  <span class="dt">&quot;number&quot;</span><span class="fu">:</span> <span class="st">&quot;0x57f898&quot;</span><span class="fu">,</span></span>
-            <span id="cb1-4"><a href="#cb1-4" aria-hidden="true"></a>  <span class="dt">&quot;miniBlockCount&quot;</span><span class="fu">:</span> <span class="st">&quot;0x57&quot;</span></span>
-            <span id="cb1-5"><a href="#cb1-5" aria-hidden="true"></a>  <span class="er">...</span></span>
-            <span id="cb1-6"><a href="#cb1-6" aria-hidden="true"></a><span class="fu">}</span></span></code></pre></div>
+            <p>Transactions in a mini block never span multiple EVM
+            blocks. In other words, for every mini block, the
+            transactions it contains all appear in the same EVM block.
+            Naturally, this establishes a mapping between mini blocks
+            and EVM blocks; we say a mini block is <em>included</em> in
+            an EVM block if the former contains transactions that appear
+            in the latter.</p>
+            <p>MegaETH produces an EVM block roughly every second and a
+            mini block roughly every 10 milliseconds. This implies a
+            rough 1-to-100 ratio between the number of EVM blocks and
+            the number of mini blocks. However, there is no guarantee on
+            the number of mini blocks included in an EVM block. To get
+            the precise number, developers should use the
+            <code>miniBlockCount</code> field in the responses when
+            calling <code>eth_subscribe</code> to subscribe to
+            <code>newHeads</code>. This is an example of the
+            responses:</p>
+            <div class="sourceCode" id="cb1"><pre
+            class="sourceCode json"><code class="sourceCode json"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="er">...</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;number&quot;</span><span class="fu">:</span> <span class="st">&quot;0x57f898&quot;</span><span class="fu">,</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;miniBlockCount&quot;</span><span class="fu">:</span> <span class="st">&quot;0x57&quot;</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>  <span class="er">...</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
         </main>
 
         <footer class="site-footer">

--- a/public/realtime-api.html
+++ b/public/realtime-api.html
@@ -51,30 +51,51 @@
                 
                                 <nav id="TOC">
                     <ul>
-                    <li><a href="#overview-of-the-changes">Overview of the Changes</a></li>
-                    <li><a href="#querying-account-and-chain-states">Querying Account and Chain States</a>
+                    <li><a href="#overview-of-the-changes"
+                    id="toc-overview-of-the-changes">Overview of the
+                    Changes</a></li>
+                    <li><a href="#querying-account-and-chain-states"
+                    id="toc-querying-account-and-chain-states">Querying
+                    Account and Chain States</a>
                     <ul>
-                    <li><a href="#example">Example</a></li>
+                    <li><a href="#example"
+                    id="toc-example">Example</a></li>
                     </ul></li>
-                    <li><a href="#querying-transactions">Querying Transactions</a>
+                    <li><a href="#querying-transactions"
+                    id="toc-querying-transactions">Querying
+                    Transactions</a>
                     <ul>
-                    <li><a href="#example-1">Example</a></li>
+                    <li><a href="#example-1"
+                    id="toc-example-1">Example</a></li>
                     </ul></li>
-                    <li><a href="#eth_subscribe-over-websocket"><code>eth_subscribe</code> over WebSocket</a>
+                    <li><a href="#eth_subscribe-over-websocket"
+                    id="toc-eth_subscribe-over-websocket"><code>eth_subscribe</code>
+                    over WebSocket</a>
                     <ul>
-                    <li><a href="#logs">Logs</a></li>
-                    <li><a href="#state-changes">State Changes</a></li>
-                    <li><a href="#mini-blocks">Mini Blocks</a></li>
+                    <li><a href="#logs" id="toc-logs">Logs</a></li>
+                    <li><a href="#state-changes"
+                    id="toc-state-changes">State Changes</a></li>
+                    <li><a href="#mini-blocks" id="toc-mini-blocks">Mini
+                    Blocks</a></li>
                     </ul></li>
-                    <li><a href="#sending-and-confirming-transactions-in-one-round-trip">Sending and Confirming Transactions in One Round Trip</a>
+                    <li><a
+                    href="#sending-and-confirming-transactions-in-one-round-trip"
+                    id="toc-sending-and-confirming-transactions-in-one-round-trip">Sending
+                    and Confirming Transactions in One Round Trip</a>
                     <ul>
-                    <li><a href="#overview">Overview</a></li>
-                    <li><a href="#example-2">Example</a></li>
+                    <li><a href="#overview"
+                    id="toc-overview">Overview</a></li>
+                    <li><a href="#example-2"
+                    id="toc-example-2">Example</a></li>
                     </ul></li>
-                    <li><a href="#paginated-log-queries-with-cursors">Paginated Log Queries with Cursors</a>
+                    <li><a href="#paginated-log-queries-with-cursors"
+                    id="toc-paginated-log-queries-with-cursors">Paginated
+                    Log Queries with Cursors</a>
                     <ul>
-                    <li><a href="#overview-1">Overview</a></li>
-                    <li><a href="#example-3">Example</a></li>
+                    <li><a href="#overview-1"
+                    id="toc-overview-1">Overview</a></li>
+                    <li><a href="#example-3"
+                    id="toc-example-3">Example</a></li>
                     </ul></li>
                     </ul>
                 </nav>
@@ -82,21 +103,59 @@
         </header>
 
         <main class="site-content">
-            <p>MegaETH executes transactions as soon as they arrive at the sequencer. The sequencer emits <em>preconfirmations</em> and <em>execution results</em> of the transactions within 10 milliseconds of their arrival at the sequencer.</p>
-            <p>Such information is exposed through MegaETH’s <em>Realtime API</em>, an extension to Ethereum JSON-RPC API optimized for low-latency access. This API queries against the most recent <em>mini block</em>. In other words, receipts and state changes associated with a transaction are reflected in this API as soon as the transaction is packaged into a mini block, which usually happens within 10 milliseconds of its arrival at the sequencer. In comparison, the vanilla Ethereum JSON-RPC API queries against the most recent <em>EVM block</em>, which leads to much longer delay before execution results are reflected.</p>
-            <p>It is important to note that mini blocks in MegaETH are preconfirmed by the sequencer just like EVM blocks are. The sequencer makes as much effort not to roll back mini blocks as it does EVM blocks. Thus, results returned by the Realtime API still fall under the preconfirmation guarantee by the sequencer.</p>
-            <p>This document specifies the Realtime API. Note that the Realtime API is an evolving standard. Additional functionalities will be added to the API based on feedbacks. This document will be kept up to date.</p>
-            <h2 id="overview-of-the-changes">Overview of the Changes</h2>
-            <p>The Realtime API introduces three types of changes to the vanilla Ethereum JSON-RPC API:</p>
+            <p>MegaETH executes transactions as soon as they arrive at
+            the sequencer. The sequencer emits <em>preconfirmations</em>
+            and <em>execution results</em> of the transactions within 10
+            milliseconds of their arrival at the sequencer.</p>
+            <p>Such information is exposed through MegaETH’s
+            <em>Realtime API</em>, an extension to Ethereum JSON-RPC API
+            optimized for low-latency access. This API queries against
+            the most recent <em>mini block</em>. In other words,
+            receipts and state changes associated with a transaction are
+            reflected in this API as soon as the transaction is packaged
+            into a mini block, which usually happens within 10
+            milliseconds of its arrival at the sequencer. In comparison,
+            the vanilla Ethereum JSON-RPC API queries against the most
+            recent <em>EVM block</em>, which leads to much longer delay
+            before execution results are reflected.</p>
+            <p>It is important to note that mini blocks in MegaETH are
+            preconfirmed by the sequencer just like EVM blocks are. The
+            sequencer makes as much effort not to roll back mini blocks
+            as it does EVM blocks. Thus, results returned by the
+            Realtime API still fall under the preconfirmation guarantee
+            by the sequencer.</p>
+            <p>This document specifies the Realtime API. Note that the
+            Realtime API is an evolving standard. Additional
+            functionalities will be added to the API based on feedbacks.
+            This document will be kept up to date.</p>
+            <h2 id="overview-of-the-changes">Overview of the
+            Changes</h2>
+            <p>The Realtime API introduces three types of changes to the
+            vanilla Ethereum JSON-RPC API:</p>
             <ol type="1">
-            <li>Most methods that query chain and account states return values as of the most recent mini block, when invoked with <code>pending</code> or <code>latest</code> as the block tag.</li>
-            <li>Most methods that query transaction data are able to “see” a transaction and return results as soon as the transaction of interest is packaged into a mini block.</li>
-            <li><code>eth_subscribe</code>, when invoked over WebSocket, streams transaction logs, state changes, and block content as soon as the corresponding mini block is produced.</li>
-            <li><code>realtime_sendRawTransaction</code> submits a transaction and returns the receipt in a single call — without requiring polling.</li>
-            <li><code>eth_getLogsWithCursor</code> supports paginated log queries using a cursor, allowing applications to retrieve large datasets incrementally and reliably.</li>
+            <li>Most methods that query chain and account states return
+            values as of the most recent mini block, when invoked with
+            <code>pending</code> or <code>latest</code> as the block
+            tag.</li>
+            <li>Most methods that query transaction data are able to
+            “see” a transaction and return results as soon as the
+            transaction of interest is packaged into a mini block.</li>
+            <li><code>eth_subscribe</code>, when invoked over WebSocket,
+            streams transaction logs, state changes, and block content
+            as soon as the corresponding mini block is produced.</li>
+            <li><code>realtime_sendRawTransaction</code> submits a
+            transaction and returns the receipt in a single call —
+            without requiring polling.</li>
+            <li><code>eth_getLogsWithCursor</code> supports paginated
+            log queries using a cursor, allowing applications to
+            retrieve large datasets incrementally and reliably.</li>
             </ol>
-            <h2 id="querying-account-and-chain-states">Querying Account and Chain States</h2>
-            <p>The following API methods that query account and chain states, when invoked with <code>pending</code> or <code>latest</code> as the block tag, return results up to the most recent mini block.</p>
+            <h2 id="querying-account-and-chain-states">Querying Account
+            and Chain States</h2>
+            <p>The following API methods that query account and chain
+            states, when invoked with <code>pending</code> or
+            <code>latest</code> as the block tag, return results up to
+            the most recent mini block.</p>
             <table>
             <thead>
             <tr class="header">
@@ -131,11 +190,32 @@
             </tbody>
             </table>
             <h3 id="example">Example</h3>
-            <p>At 5pm, the height of the most recent mini block is 10000, and the height of the most recent EVM block is 100. At this point, Alice’s account has a balance of 10 Ether.</p>
-            <p>At 100 milliseconds past 5pm, the height of the most recent mini block is 10010, and the height of the most recent EVM block is still 100. Now, Alice sends a transaction that transfers 1 Ether to Bob. This transaction will decrease her account balance by 1 Ether.</p>
-            <p>At 110 milliseconds past 5pm, the transaction is picked up and executed by the sequencer, and packaged into the mini block at height 10011. Now, Bob invokes <code>eth_getBalance</code> on Alice’s account with <code>latest</code> as the block tag; he get a response of 9 Ether, because the transaction has been packaged into a mini block and is thus reflected in the Realtime API. However, Charlie, who makes the same query with <code>100</code> as the block tag, still sees 10 Ether, because the transaction has not been packaged into an EVM block, which will not happen until 1 second past 5pm.</p>
+            <p>At 5pm, the height of the most recent mini block is
+            10000, and the height of the most recent EVM block is 100.
+            At this point, Alice’s account has a balance of 10
+            Ether.</p>
+            <p>At 100 milliseconds past 5pm, the height of the most
+            recent mini block is 10010, and the height of the most
+            recent EVM block is still 100. Now, Alice sends a
+            transaction that transfers 1 Ether to Bob. This transaction
+            will decrease her account balance by 1 Ether.</p>
+            <p>At 110 milliseconds past 5pm, the transaction is picked
+            up and executed by the sequencer, and packaged into the mini
+            block at height 10011. Now, Bob invokes
+            <code>eth_getBalance</code> on Alice’s account with
+            <code>latest</code> as the block tag; he get a response of 9
+            Ether, because the transaction has been packaged into a mini
+            block and is thus reflected in the Realtime API. However,
+            Charlie, who makes the same query with <code>100</code> as
+            the block tag, still sees 10 Ether, because the transaction
+            has not been packaged into an EVM block, which will not
+            happen until 1 second past 5pm.</p>
             <h2 id="querying-transactions">Querying Transactions</h2>
-            <p>The following API methods that query transaction data are able to locate a transaction in the database and return results as soon as the transaction is packaged into a mini block. No special parameters are needed when invoking the methods.</p>
+            <p>The following API methods that query transaction data are
+            able to locate a transaction in the database and return
+            results as soon as the transaction is packaged into a mini
+            block. No special parameters are needed when invoking the
+            methods.</p>
             <table>
             <thead>
             <tr class="header">
@@ -152,212 +232,293 @@
             </tbody>
             </table>
             <h3 id="example-1">Example</h3>
-            <p>Continuing the previous example, Alice invokes <code>eth_getTransactionReceipt</code> on her transaction at 110 milliseconds past 5pm. The API responds with the correct receipt, even though no EVM block has been produced since she sent her transaction. This is because her transaction is already packaged into the mini block at height 10011 and the Realtime API can thus see the transaction.</p>
-            <h2 id="eth_subscribe-over-websocket"><code>eth_subscribe</code> over WebSocket</h2>
-            <p>When invoked over WebSocket, <code>eth_subscribe</code> streams data as soon as the corresponding mini block is produced. This is the mechanism to get transaction preconfirmation and execution results with the minimum amount of latency. As a reminder, please call <code>eth_unsubscribe</code> when a subscription is no longer needed.</p>
-            <p><strong>Note:</strong> WebSocket connections require periodic client activity to remain open. Clients should send <code>eth_chainId</code> at least once every 30 seconds to keep the WebSocket connection alive. Idle connections may be closed by the server.</p>
+            <p>Continuing the previous example, Alice invokes
+            <code>eth_getTransactionReceipt</code> on her transaction at
+            110 milliseconds past 5pm. The API responds with the correct
+            receipt, even though no EVM block has been produced since
+            she sent her transaction. This is because her transaction is
+            already packaged into the mini block at height 10011 and the
+            Realtime API can thus see the transaction.</p>
+            <h2
+            id="eth_subscribe-over-websocket"><code>eth_subscribe</code>
+            over WebSocket</h2>
+            <p>When invoked over WebSocket, <code>eth_subscribe</code>
+            streams data as soon as the corresponding mini block is
+            produced. This is the mechanism to get transaction
+            preconfirmation and execution results with the minimum
+            amount of latency. As a reminder, please call
+            <code>eth_unsubscribe</code> when a subscription is no
+            longer needed.</p>
+            <p><strong>Note:</strong> WebSocket connections require
+            periodic client activity to remain open. Clients should send
+            <code>eth_chainId</code> at least once every 30 seconds to
+            keep the WebSocket connection alive. Idle connections may be
+            closed by the server.</p>
             <h3 id="logs">Logs</h3>
-            <p>When both <code>startBlock</code> and <code>endBlock</code> are set to <code>pending</code>, the API returns logs as soon as transactions are packaged into mini blocks. The following query is an example.</p>
+            <p>When both <code>startBlock</code> and
+            <code>endBlock</code> are set to <code>pending</code>, the
+            API returns logs as soon as transactions are packaged into
+            mini blocks. The following query is an example.</p>
             <pre><code>{
-                &quot;jsonrpc&quot;: &quot;2.0&quot;,
-                &quot;method&quot;: &quot;eth_subscribe&quot;,
-                &quot;params&quot;: [
-                    &quot;logs&quot;,
-                    {
-                        &quot;fromBlock&quot;: &quot;pending&quot;,
-                        &quot;toBlock&quot;: &quot;pending&quot;
-                    }
-                ],
-                &quot;id&quot;: 83
-            }</code></pre>
-            <p>It is also possible to filter the logs by contract addresses and topics. Here is an example.</p>
+    &quot;jsonrpc&quot;: &quot;2.0&quot;,
+    &quot;method&quot;: &quot;eth_subscribe&quot;,
+    &quot;params&quot;: [
+        &quot;logs&quot;,
+        {
+            &quot;fromBlock&quot;: &quot;pending&quot;,
+            &quot;toBlock&quot;: &quot;pending&quot;
+        }
+    ],
+    &quot;id&quot;: 83
+}</code></pre>
+            <p>It is also possible to filter the logs by contract
+            addresses and topics. Here is an example.</p>
             <pre><code>{
-                &quot;jsonrpc&quot;: &quot;2.0&quot;,
-                &quot;method&quot;: &quot;eth_subscribe&quot;,
-                &quot;params&quot;: [
-                    &quot;logs&quot;,
-                    {
-                        &quot;address&quot;: &quot;0x8320fe7702b96808f7bbc0d4a888ed1468216cfd&quot;,
-                        &quot;topics&quot;: [&quot;0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902&quot;],
-                        &quot;fromBlock&quot;: &quot;pending&quot;,
-                        &quot;toBlock&quot;: &quot;pending&quot;
-                    }
-                ],
-                &quot;id&quot;: 83
-            }</code></pre>
-            <p>The schema of each log entry is the same as in <code>eth_getLogs</code>.</p>
+    &quot;jsonrpc&quot;: &quot;2.0&quot;,
+    &quot;method&quot;: &quot;eth_subscribe&quot;,
+    &quot;params&quot;: [
+        &quot;logs&quot;,
+        {
+            &quot;address&quot;: &quot;0x8320fe7702b96808f7bbc0d4a888ed1468216cfd&quot;,
+            &quot;topics&quot;: [&quot;0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902&quot;],
+            &quot;fromBlock&quot;: &quot;pending&quot;,
+            &quot;toBlock&quot;: &quot;pending&quot;
+        }
+    ],
+    &quot;id&quot;: 83
+}</code></pre>
+            <p>The schema of each log entry is the same as in
+            <code>eth_getLogs</code>.</p>
             <h3 id="state-changes">State Changes</h3>
-            <p><code>stateChanges</code> is a new type of subscription that streams state changes of an account as soon as the transactions making the changes are packaged into mini blocks. It takes a list of account addresses to monitor as a parameter. Here is an example.</p>
+            <p><code>stateChanges</code> is a new type of subscription
+            that streams state changes of an account as soon as the
+            transactions making the changes are packaged into mini
+            blocks. It takes a list of account addresses to monitor as a
+            parameter. Here is an example.</p>
             <pre><code>{
-                &quot;jsonrpc&quot;: &quot;2.0&quot;,
-                &quot;method&quot;: &quot;eth_subscribe&quot;,
-                &quot;params&quot;: [
-                    &quot;stateChanges&quot;,
-                    [&quot;0x2ef038991d64c72646d4f06ba78d93f4f1654e3f&quot;]
-                ],
-                &quot;id&quot;: 83
-            }</code></pre>
-            <p>Here is an example of the response. It shows the latest account balance, nonce, and values of storage slots that are changed. The schema is as the following.</p>
+    &quot;jsonrpc&quot;: &quot;2.0&quot;,
+    &quot;method&quot;: &quot;eth_subscribe&quot;,
+    &quot;params&quot;: [
+        &quot;stateChanges&quot;,
+        [&quot;0x2ef038991d64c72646d4f06ba78d93f4f1654e3f&quot;]
+    ],
+    &quot;id&quot;: 83
+}</code></pre>
+            <p>Here is an example of the response. It shows the latest
+            account balance, nonce, and values of storage slots that are
+            changed. The schema is as the following.</p>
             <pre><code>{
-                &quot;address&quot;: Address, // The address of the account that is changed.
-                &quot;nonce&quot;: number, // The latest nonce of the account.
-                &quot;balance&quot;: U256, // The latest balance of the account.
-                &quot;storage&quot;: { // Updated storage slots and new values of the account.
-                   U256: U256,
-                   ... 
-                }
-            }
-            </code></pre>
+    &quot;address&quot;: Address, // The address of the account that is changed.
+    &quot;nonce&quot;: number, // The latest nonce of the account.
+    &quot;balance&quot;: U256, // The latest balance of the account.
+    &quot;storage&quot;: { // Updated storage slots and new values of the account.
+       U256: U256,
+       ... 
+    }
+}
+</code></pre>
             <p>Here is an example.</p>
             <pre><code>{
-                &quot;address&quot;: &quot;0x2ef038991d64c72646d4f06ba78d93f4f1654e3f&quot;,
-                &quot;nonce&quot;: 1,
-                &quot;balance&quot;: &quot;0x16345785d8a0000&quot;,
-                &quot;storage&quot;: {
-                &quot;0xb6318d15e99499c465cc5e3d630975bf37b5641a8beb2614b018219310f4ea12&quot;: &quot;0x68836e425f5&quot;,
-                &quot;0xbf0f571b7368c19b53ab5ef0ff767ed8e0aef55a462778a6119b7871b017ce8f&quot;: &quot;0x71094412456b0&quot;
-                }
-            }</code></pre>
+    &quot;address&quot;: &quot;0x2ef038991d64c72646d4f06ba78d93f4f1654e3f&quot;,
+    &quot;nonce&quot;: 1,
+    &quot;balance&quot;: &quot;0x16345785d8a0000&quot;,
+    &quot;storage&quot;: {
+    &quot;0xb6318d15e99499c465cc5e3d630975bf37b5641a8beb2614b018219310f4ea12&quot;: &quot;0x68836e425f5&quot;,
+    &quot;0xbf0f571b7368c19b53ab5ef0ff767ed8e0aef55a462778a6119b7871b017ce8f&quot;: &quot;0x71094412456b0&quot;
+    }
+}</code></pre>
             <h3 id="mini-blocks">Mini Blocks</h3>
-            <p><code>miniBlocks</code> is a new type of subscription that streams mini blocks as they are produced. Here is an example.</p>
+            <p><code>miniBlocks</code> is a new type of subscription
+            that streams mini blocks as they are produced. Here is an
+            example.</p>
             <pre><code>{
-                &quot;jsonrpc&quot;: &quot;2.0&quot;,
-                &quot;method&quot;: &quot;eth_subscribe&quot;,
-                &quot;params&quot;: [
-                    &quot;miniBlocks&quot;
-                ],
-                &quot;id&quot;: 83
-            }</code></pre>
+    &quot;jsonrpc&quot;: &quot;2.0&quot;,
+    &quot;method&quot;: &quot;eth_subscribe&quot;,
+    &quot;params&quot;: [
+        &quot;miniBlocks&quot;
+    ],
+    &quot;id&quot;: 83
+}</code></pre>
             <p>The returned mini blocks use the following schema.</p>
             <pre><code>{
-                 &quot;block_number&quot;: HexString, // The block number of that EVM block that this mini-block belongs to
-                 &quot;block_timestamp&quot;: HexString, // Timestamp of the EVM block
-                 &quot;index&quot;: HexString, // Index of this mini-block in the EVM block
-                 &quot;mini_block_number&quot;: HexString, // The number of this mini-block in blockchain history
-                 &quot;mini_block_timestamp&quot;: HexString, // The timestamp when this mini-block is created. Unix timestamp in microseconds.
-                 &quot;gas_used&quot;: HexString, // Gas used inside this mini-block
-                 &quot;transactions&quot;: [ ... ], // Transactions included in this mini-block. The schema of each transaction is the same as `eth_getTransactionByHash`.
-                 &quot;receipts&quot;: [ ... ] // Receipts of the transactions in this mini-block. The schema of each receipt is the same as `eth_getTransactionReceipt`.
-            }</code></pre>
-            <h2 id="sending-and-confirming-transactions-in-one-round-trip">Sending and Confirming Transactions in One Round Trip</h2>
+     &quot;block_number&quot;: HexString, // The block number of that EVM block that this mini-block belongs to
+     &quot;block_timestamp&quot;: HexString, // Timestamp of the EVM block
+     &quot;index&quot;: HexString, // Index of this mini-block in the EVM block
+     &quot;mini_block_number&quot;: HexString, // The number of this mini-block in blockchain history
+     &quot;mini_block_timestamp&quot;: HexString, // The timestamp when this mini-block is created. Unix timestamp in microseconds.
+     &quot;gas_used&quot;: HexString, // Gas used inside this mini-block
+     &quot;transactions&quot;: [ ... ], // Transactions included in this mini-block. The schema of each transaction is the same as `eth_getTransactionByHash`.
+     &quot;receipts&quot;: [ ... ] // Receipts of the transactions in this mini-block. The schema of each receipt is the same as `eth_getTransactionReceipt`.
+}</code></pre>
+            <h2
+            id="sending-and-confirming-transactions-in-one-round-trip">Sending
+            and Confirming Transactions in One Round Trip</h2>
             <h3 id="overview">Overview</h3>
-            <p><code>realtime_sendRawTransaction</code> simplifies realtime dApp development by returning the transaction receipt directly, without requiring polling <code>eth_getTransactionReceipt</code>. It accepts the same parameters as <code>eth_sendRawTransaction</code> but waits for the transaction to be executed and returns its receipt as the response. This method times out after 10 seconds, in which case it returns a <code>realtime transaction expired</code> error, indicating that the user should revert to querying <code>eth_getTransactionReceipt</code>.</p>
+            <p><code>realtime_sendRawTransaction</code> simplifies
+            realtime dApp development by returning the transaction
+            receipt directly, without requiring polling
+            <code>eth_getTransactionReceipt</code>. It accepts the same
+            parameters as <code>eth_sendRawTransaction</code> but waits
+            for the transaction to be executed and returns its receipt
+            as the response. This method times out after 10 seconds, in
+            which case it returns a
+            <code>realtime transaction expired</code> error, indicating
+            that the user should revert to querying
+            <code>eth_getTransactionReceipt</code>.</p>
             <h3 id="example-2">Example</h3>
-            <p><code>realtime_sendRawTransaction</code> is a drop-in replacement of <code>eth_sendRawTransaction</code>.</p>
+            <p><code>realtime_sendRawTransaction</code> is a drop-in
+            replacement of <code>eth_sendRawTransaction</code>.</p>
             <pre><code>{
-              &quot;jsonrpc&quot;: &quot;2.0&quot;,
-              &quot;method&quot;: &quot;realtime_sendRawTransaction&quot;,
-              &quot;params&quot;: [
-                &quot;0x&lt;hex-encoded-signed-tx&gt;&quot;
-              ],
-              &quot;id&quot;: 1
-            }</code></pre>
-            <p>If the submitted transaction is executed within 10 seconds, it returns the receipt of the executed transaction.</p>
+  &quot;jsonrpc&quot;: &quot;2.0&quot;,
+  &quot;method&quot;: &quot;realtime_sendRawTransaction&quot;,
+  &quot;params&quot;: [
+    &quot;0x&lt;hex-encoded-signed-tx&gt;&quot;
+  ],
+  &quot;id&quot;: 1
+}</code></pre>
+            <p>If the submitted transaction is executed within 10
+            seconds, it returns the receipt of the executed
+            transaction.</p>
             <pre><code>{
-              &quot;jsonrpc&quot;: &quot;2.0&quot;,
-              &quot;id&quot;: 1,
-              &quot;result&quot;: {
-                &quot;blockHash&quot;: &quot;0x0000000000000000000000000000000000000000000000000000000000000000&quot;,
-                &quot;blockNumber&quot;: &quot;0x10&quot;,
-                &quot;contractAddress&quot;: null,
-                &quot;cumulativeGasUsed&quot;: &quot;0x11dde&quot;,
-                &quot;effectiveGasPrice&quot;: &quot;0x23ebdf&quot;,
-                &quot;from&quot;: &quot;0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266&quot;,
-                &quot;gasUsed&quot;: &quot;0x5208&quot;,
-                &quot;logs&quot;: [],
-                &quot;logsBloom&quot;: &quot;0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000&quot;,
-                &quot;status&quot;: &quot;0x1&quot;,
-                &quot;to&quot;: &quot;0xa7b8c275b3dde39e69a5c0ffd9f34f974364941a&quot;,
-                &quot;transactionHash&quot;: &quot;0xf98a6b5de84ee59666d0ff3d8c361f308c3a22fc0bb94466810777d60a3ed7a7&quot;,
-                &quot;transactionIndex&quot;: &quot;0x1&quot;,
-                &quot;type&quot;: &quot;0x0&quot;
-              }
-            }</code></pre>
-            <p>If the transaction is not executed within 10 seconds, e.g., because of congestion at the sequencer, it returns an error.</p>
+  &quot;jsonrpc&quot;: &quot;2.0&quot;,
+  &quot;id&quot;: 1,
+  &quot;result&quot;: {
+    &quot;blockHash&quot;: &quot;0x0000000000000000000000000000000000000000000000000000000000000000&quot;,
+    &quot;blockNumber&quot;: &quot;0x10&quot;,
+    &quot;contractAddress&quot;: null,
+    &quot;cumulativeGasUsed&quot;: &quot;0x11dde&quot;,
+    &quot;effectiveGasPrice&quot;: &quot;0x23ebdf&quot;,
+    &quot;from&quot;: &quot;0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266&quot;,
+    &quot;gasUsed&quot;: &quot;0x5208&quot;,
+    &quot;logs&quot;: [],
+    &quot;logsBloom&quot;: &quot;0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000&quot;,
+    &quot;status&quot;: &quot;0x1&quot;,
+    &quot;to&quot;: &quot;0xa7b8c275b3dde39e69a5c0ffd9f34f974364941a&quot;,
+    &quot;transactionHash&quot;: &quot;0xf98a6b5de84ee59666d0ff3d8c361f308c3a22fc0bb94466810777d60a3ed7a7&quot;,
+    &quot;transactionIndex&quot;: &quot;0x1&quot;,
+    &quot;type&quot;: &quot;0x0&quot;
+  }
+}</code></pre>
+            <p>If the transaction is not executed within 10 seconds,
+            e.g., because of congestion at the sequencer, it returns an
+            error.</p>
             <pre><code>{
-              &quot;jsonrpc&quot;: &quot;2.0&quot;,
-              &quot;id&quot;: 1,
-              &quot;error&quot;: {
-                &quot;code&quot;: -32000,
-                &quot;message&quot;: &quot;realtime transaction expired&quot;
-              }
-            }</code></pre>
-            <h2 id="paginated-log-queries-with-cursors">Paginated Log Queries with Cursors</h2>
+  &quot;jsonrpc&quot;: &quot;2.0&quot;,
+  &quot;id&quot;: 1,
+  &quot;error&quot;: {
+    &quot;code&quot;: -32000,
+    &quot;message&quot;: &quot;realtime transaction expired&quot;
+  }
+}</code></pre>
+            <h2 id="paginated-log-queries-with-cursors">Paginated Log
+            Queries with Cursors</h2>
             <h3 id="overview-1">Overview</h3>
-            <p><code>eth_getLogsWithCursor</code> is an enhanced version of <code>eth_getLogs</code> that adds support for pagination via a cursor. This allows applications to query large sets of logs while gracefully handing execution or memory limits on the RPC server. When a query exceeds server-side resource caps, the server returns a partial result and a cursor that marks where it left off. The client can then continue the query from that point.</p>
-            <p>This method accepts the same parameters as <code>eth_getLogs</code>, with an additional optional <code>cursor</code>, which is an opaque string. If the query is too large and hits the server-side caps, it returns a partial list of logs and a <code>cursor</code> pointing to the next log to fetch. Clients can resume the query using the provided <code>cursor</code>. Absence of a <code>cursor</code> in the request indicates that the server should start the query at <code>fromBlock</code> as usual. Absence of a returned <code>cursor</code> indicates the query is complete. The cursor is derived from <code>(blockNumber + logIndex)</code> of the last log in the current batch, but users should treat it as an opaque string.</p>
+            <p><code>eth_getLogsWithCursor</code> is an enhanced version
+            of <code>eth_getLogs</code> that adds support for pagination
+            via a cursor. This allows applications to query large sets
+            of logs while gracefully handing execution or memory limits
+            on the RPC server. When a query exceeds server-side resource
+            caps, the server returns a partial result and a cursor that
+            marks where it left off. The client can then continue the
+            query from that point.</p>
+            <p>This method accepts the same parameters as
+            <code>eth_getLogs</code>, with an additional optional
+            <code>cursor</code>, which is an opaque string. If the query
+            is too large and hits the server-side caps, it returns a
+            partial list of logs and a <code>cursor</code> pointing to
+            the next log to fetch. Clients can resume the query using
+            the provided <code>cursor</code>. Absence of a
+            <code>cursor</code> in the request indicates that the server
+            should start the query at <code>fromBlock</code> as usual.
+            Absence of a returned <code>cursor</code> indicates the
+            query is complete. The cursor is derived from
+            <code>(blockNumber + logIndex)</code> of the last log in the
+            current batch, but users should treat it as an opaque
+            string.</p>
             <h3 id="example-3">Example</h3>
-            <p>To send an initial request, start with a standard <code>eth_getLogs</code>-style query. Set <code>fromBlock</code> and <code>toBlock</code> (or <code>blockHash</code>) and do <em>not</em> include a cursor.</p>
+            <p>To send an initial request, start with a standard
+            <code>eth_getLogs</code>-style query. Set
+            <code>fromBlock</code> and <code>toBlock</code> (or
+            <code>blockHash</code>) and do <em>not</em> include a
+            cursor.</p>
             <pre><code>{
-              &quot;jsonrpc&quot;: &quot;2.0&quot;,
-              &quot;method&quot;: &quot;eth_getLogsWithCursor&quot;,
-              &quot;params&quot;: [
-                {
-                  &quot;fromBlock&quot;: &quot;0x100&quot;,
-                  &quot;toBlock&quot;: &quot;0x200&quot;,
-                  &quot;address&quot;: &quot;0x1234567890abcdef1234567890abcdef12345678&quot;,
-                  &quot;topics&quot;: [&quot;0xddf252ad...&quot;]
-                }
-              ],
-              &quot;id&quot;: 1
-            }</code></pre>
-            <p>If the server reaches its processing limit (e.g. max logs or execution time), it will return the logs retrieved so far and include a <code>cursor</code> indicating the last log processed.</p>
+  &quot;jsonrpc&quot;: &quot;2.0&quot;,
+  &quot;method&quot;: &quot;eth_getLogsWithCursor&quot;,
+  &quot;params&quot;: [
+    {
+      &quot;fromBlock&quot;: &quot;0x100&quot;,
+      &quot;toBlock&quot;: &quot;0x200&quot;,
+      &quot;address&quot;: &quot;0x1234567890abcdef1234567890abcdef12345678&quot;,
+      &quot;topics&quot;: [&quot;0xddf252ad...&quot;]
+    }
+  ],
+  &quot;id&quot;: 1
+}</code></pre>
+            <p>If the server reaches its processing limit (e.g. max logs
+            or execution time), it will return the logs retrieved so far
+            and include a <code>cursor</code> indicating the last log
+            processed.</p>
             <pre><code>{
-              &quot;jsonrpc&quot;: &quot;2.0&quot;,
-              &quot;id&quot;: 1,
-              &quot;result&quot;: {
-                &quot;logs&quot;: [
-                  {
-                    &quot;address&quot;: &quot;0x1234567890abcdef1234567890abcdef12345678&quot;,
-                    &quot;blockNumber&quot;: &quot;0x101&quot;,
-                    &quot;logIndex&quot;: &quot;0x0&quot;,
-                    &quot;topics&quot;: [&quot;0xddf252ad...&quot;],
-                    &quot;data&quot;: &quot;0x...&quot;,
-                    &quot;transactionHash&quot;: &quot;0x...&quot;,
-                    &quot;transactionIndex&quot;: &quot;0x0&quot;,
-                    &quot;blockHash&quot;: &quot;0x...&quot;,
-                    &quot;removed&quot;: false
-                  }
-                ],
-                &quot;cursor&quot;: &quot;0x0000010100000000&quot;  
-              }
-            }</code></pre>
-            <p>The client should submit a second request with the same filter (e.g. address, topics, block range) and the <code>cursor</code> from the previous response (mandatory). The server will resume the query from where it left off.</p>
+  &quot;jsonrpc&quot;: &quot;2.0&quot;,
+  &quot;id&quot;: 1,
+  &quot;result&quot;: {
+    &quot;logs&quot;: [
+      {
+        &quot;address&quot;: &quot;0x1234567890abcdef1234567890abcdef12345678&quot;,
+        &quot;blockNumber&quot;: &quot;0x101&quot;,
+        &quot;logIndex&quot;: &quot;0x0&quot;,
+        &quot;topics&quot;: [&quot;0xddf252ad...&quot;],
+        &quot;data&quot;: &quot;0x...&quot;,
+        &quot;transactionHash&quot;: &quot;0x...&quot;,
+        &quot;transactionIndex&quot;: &quot;0x0&quot;,
+        &quot;blockHash&quot;: &quot;0x...&quot;,
+        &quot;removed&quot;: false
+      }
+    ],
+    &quot;cursor&quot;: &quot;0x0000010100000000&quot;  
+  }
+}</code></pre>
+            <p>The client should submit a second request with the same
+            filter (e.g. address, topics, block range) and the
+            <code>cursor</code> from the previous response (mandatory).
+            The server will resume the query from where it left off.</p>
             <pre><code>{
-              &quot;jsonrpc&quot;: &quot;2.0&quot;,
-              &quot;method&quot;: &quot;eth_getLogsWithCursor&quot;,
-              &quot;params&quot;: [
-                {
-                  &quot;fromBlock&quot;: &quot;0x100&quot;,
-                  &quot;toBlock&quot;: &quot;0x200&quot;,
-                  &quot;address&quot;: &quot;0x1234567890abcdef1234567890abcdef12345678&quot;,
-                  &quot;topics&quot;: [&quot;0xddf252ad...&quot;],
-                  &quot;cursor&quot;: &quot;0x0000010100000000&quot;
-                }
-              ],
-              &quot;id&quot;: 2
-            }</code></pre>
-            <p>When the server returns a response <em>without</em> a <code>cursor</code>, it means that all matching logs have been retrieved and no further requests are needed</p>
+  &quot;jsonrpc&quot;: &quot;2.0&quot;,
+  &quot;method&quot;: &quot;eth_getLogsWithCursor&quot;,
+  &quot;params&quot;: [
+    {
+      &quot;fromBlock&quot;: &quot;0x100&quot;,
+      &quot;toBlock&quot;: &quot;0x200&quot;,
+      &quot;address&quot;: &quot;0x1234567890abcdef1234567890abcdef12345678&quot;,
+      &quot;topics&quot;: [&quot;0xddf252ad...&quot;],
+      &quot;cursor&quot;: &quot;0x0000010100000000&quot;
+    }
+  ],
+  &quot;id&quot;: 2
+}</code></pre>
+            <p>When the server returns a response <em>without</em> a
+            <code>cursor</code>, it means that all matching logs have
+            been retrieved and no further requests are needed</p>
             <pre><code>{
-              &quot;jsonrpc&quot;: &quot;2.0&quot;,
-              &quot;id&quot;: 2,
-              &quot;result&quot;: {
-                &quot;logs&quot;: [
-                  {
-                    &quot;address&quot;: &quot;0x1234567890abcdef1234567890abcdef12345678&quot;,
-                    &quot;blockNumber&quot;: &quot;0x102&quot;,
-                    &quot;logIndex&quot;: &quot;0x3&quot;,
-                    &quot;topics&quot;: [&quot;0xddf252ad...&quot;],
-                    &quot;data&quot;: &quot;0x...&quot;,
-                    &quot;transactionHash&quot;: &quot;0x...&quot;,
-                    &quot;transactionIndex&quot;: &quot;0x2&quot;,
-                    &quot;blockHash&quot;: &quot;0x...&quot;,
-                    &quot;removed&quot;: false
-                  }
-                ]
-                // No cursor field — query is complete
-              }
-            }</code></pre>
+  &quot;jsonrpc&quot;: &quot;2.0&quot;,
+  &quot;id&quot;: 2,
+  &quot;result&quot;: {
+    &quot;logs&quot;: [
+      {
+        &quot;address&quot;: &quot;0x1234567890abcdef1234567890abcdef12345678&quot;,
+        &quot;blockNumber&quot;: &quot;0x102&quot;,
+        &quot;logIndex&quot;: &quot;0x3&quot;,
+        &quot;topics&quot;: [&quot;0xddf252ad...&quot;],
+        &quot;data&quot;: &quot;0x...&quot;,
+        &quot;transactionHash&quot;: &quot;0x...&quot;,
+        &quot;transactionIndex&quot;: &quot;0x2&quot;,
+        &quot;blockHash&quot;: &quot;0x...&quot;,
+        &quot;removed&quot;: false
+      }
+    ]
+    // No cursor field — query is complete
+  }
+}</code></pre>
         </main>
 
         <footer class="site-footer">

--- a/public/rpc.html
+++ b/public/rpc.html
@@ -51,17 +51,25 @@
                 
                                 <nav id="TOC">
                     <ul>
-                    <li><a href="#available-methods">Available Methods</a></li>
-                    <li><a href="#rate-limiting">Rate Limiting</a></li>
-                    <li><a href="#error-codes">Error Codes</a></li>
+                    <li><a
+                    href="#docs__rpc__2-error-codes.md__error-codes"
+                    id="toc-docs__rpc__2-error-codes.md__error-codes">Error
+                    Codes</a></li>
                     </ul>
                 </nav>
                             </div>
         </header>
 
         <main class="site-content">
-            <h2 id="available-methods">Available Methods</h2>
+            <div id="docs__rpc__1-method.md">
+            <h2 id="docs__rpc__1-method.md__available-methods">Available
+            Methods</h2>
             <table>
+            <colgroup>
+            <col style="width: 53%" />
+            <col style="width: 16%" />
+            <col style="width: 30%" />
+            </colgroup>
             <thead>
             <tr class="header">
             <th>Method</th>
@@ -432,14 +440,23 @@
             </tr>
             </tbody>
             </table>
-            <h2 id="rate-limiting">Rate Limiting</h2>
-            <p>All available methods are subject to rate limiting based on two criteria:</p>
+            <h2 id="docs__rpc__1-method.md__rate-limiting">Rate
+            Limiting</h2>
+            <p>All available methods are subject to rate limiting based
+            on two criteria:</p>
             <ul>
-            <li><strong>Compute Unit (CU) Limiting</strong>: Limits the computational cost of requests based on their complexity.</li>
-            <li><strong>Network Bandwidth Limiting</strong>: Limits the network traffic based on response sizes.</li>
+            <li><strong>Compute Unit (CU) Limiting</strong>: Limits the
+            computational cost of requests based on their
+            complexity.</li>
+            <li><strong>Network Bandwidth Limiting</strong>: Limits the
+            network traffic based on response sizes.</li>
             </ul>
-            <p>User limits are dynamically updated in response to individual behavior.</p>
-            <h2 id="error-codes">Error Codes</h2>
+            <p>User limits are dynamically updated in response to
+            individual behavior.</p>
+            </div>
+            <div id="docs__rpc__2-error-codes.md">
+            <h2 id="docs__rpc__2-error-codes.md__error-codes">Error
+            Codes</h2>
             <table>
             <colgroup>
             <col style="width: 8%" />
@@ -463,52 +480,66 @@
             <td>-32700</td>
             <td>parse error</td>
             <td>The request body contains invalid JSON.</td>
-            <td>Check the request format and ensure valid JSON syntax.</td>
+            <td>Check the request format and ensure valid JSON
+            syntax.</td>
             </tr>
             <tr class="even">
             <td>403</td>
             <td>-32601</td>
             <td>rpc method is not whitelisted</td>
-            <td>The requested RPC method is not allowed by the proxy configuration.</td>
-            <td>Use only whitelisted RPC methods. Contact MegaETH if you need access to additional methods.</td>
+            <td>The requested RPC method is not allowed by the proxy
+            configuration.</td>
+            <td>Use only whitelisted RPC methods. Contact MegaETH if you
+            need access to additional methods.</td>
             </tr>
             <tr class="odd">
             <td>400</td>
             <td>-32019</td>
             <td>block is out of range</td>
             <td>The requested block number is out of range.</td>
-            <td>Check the block number and ensure it’s within the valid range.</td>
+            <td>Check the block number and ensure it’s within the valid
+            range.</td>
             </tr>
             <tr class="even">
             <td>500</td>
             <td>-32020</td>
             <td>backend response too large</td>
             <td>The backend response is too large.</td>
-            <td>Reduce the scope of the request or contact MegaETH for assistance.</td>
+            <td>Reduce the scope of the request or contact MegaETH for
+            assistance.</td>
             </tr>
             <tr class="odd">
             <td>429</td>
             <td>-32021</td>
             <td>over network traffic limit, retry in X seconds</td>
             <td>The user is incurring too much network traffic.</td>
-            <td>Wait for the specified number of seconds before retrying. Reduce the number of requests sent per second.</td>
+            <td>Wait for the specified number of seconds before
+            retrying. Reduce the number of requests sent per
+            second.</td>
             </tr>
             <tr class="even">
             <td>429</td>
             <td>-32022</td>
             <td>over compute unit limit, retry in X seconds</td>
-            <td>The user is incurring too much computation on the backend RPC server.</td>
-            <td>Wait for the specified number of seconds before retrying. Reduce the number of requests sent per second.</td>
+            <td>The user is incurring too much computation on the
+            backend RPC server.</td>
+            <td>Wait for the specified number of seconds before
+            retrying. Reduce the number of requests sent per
+            second.</td>
             </tr>
             <tr class="odd">
             <td>200</td>
             <td>-32000</td>
-            <td>permanent error forwarding request context deadline exceeded</td>
-            <td>The API proxy cannot connect to the backend RPC server.</td>
-            <td>Pause for a while and retry. Notify MegaETH if the error persists.</td>
+            <td>permanent error forwarding request context deadline
+            exceeded</td>
+            <td>The API proxy cannot connect to the backend RPC
+            server.</td>
+            <td>Pause for a while and retry. Notify MegaETH if the error
+            persists.</td>
             </tr>
             </tbody>
             </table>
+            </div>
         </main>
 
         <footer class="site-footer">

--- a/public/testnet.html
+++ b/public/testnet.html
@@ -51,12 +51,18 @@
                 
                                 <nav id="TOC">
                     <ul>
-                    <li><a href="#important-messages">Important Messages</a></li>
-                    <li><a href="#chain-parameters">Chain Parameters</a></li>
-                    <li><a href="#connecting-to-the-testnet">Connecting to the Testnet</a>
+                    <li><a href="#important-messages"
+                    id="toc-important-messages">Important
+                    Messages</a></li>
+                    <li><a href="#chain-parameters"
+                    id="toc-chain-parameters">Chain Parameters</a></li>
+                    <li><a href="#connecting-to-the-testnet"
+                    id="toc-connecting-to-the-testnet">Connecting to the
+                    Testnet</a>
                     <ul>
-                    <li><a href="#rpc">RPC</a></li>
-                    <li><a href="#block-explorer">Block Explorer</a></li>
+                    <li><a href="#rpc" id="toc-rpc">RPC</a></li>
+                    <li><a href="#block-explorer"
+                    id="toc-block-explorer">Block Explorer</a></li>
                     </ul></li>
                     </ul>
                 </nav>
@@ -66,12 +72,23 @@
         <main class="site-content">
             <h2 id="important-messages">Important Messages</h2>
             <ul>
-            <li><strong>RPC Endpoints Are Rate Limited And May Change.</strong> Always check this page for the latest URLs and status.</li>
-            <li><strong>Network Maintenance May Occur.</strong> RPCs may go offline during upgrades. Contracts and states may be rolled back in rare cases.</li>
-            <li><strong>Testnet Is Not Incentivized.</strong> Testnet tokens and transactions have no real monetary value. <em>Everything happening on the chain is solely for experimental purposes.</em></li>
+            <li><strong>RPC Endpoints Are Rate Limited And May
+            Change.</strong> Always check this page for the latest URLs
+            and status.</li>
+            <li><strong>Network Maintenance May Occur.</strong> RPCs may
+            go offline during upgrades. Contracts and states may be
+            rolled back in rare cases.</li>
+            <li><strong>Testnet Is Not Incentivized.</strong> Testnet
+            tokens and transactions have no real monetary value.
+            <em>Everything happening on the chain is solely for
+            experimental purposes.</em></li>
             </ul>
             <h2 id="chain-parameters">Chain Parameters</h2>
             <table>
+            <colgroup>
+            <col style="width: 22%" />
+            <col style="width: 77%" />
+            </colgroup>
             <thead>
             <tr class="header">
             <th>Item</th>
@@ -93,11 +110,14 @@
             </tr>
             <tr class="even">
             <td><strong>Block Gas Limit</strong></td>
-            <td>10 billion (<br /><span class="math display">10<sup>10</sup></span><br />) gas per EVM block</td>
+            <td>10 billion (<span
+            class="math display">10<sup>10</sup></span>) gas per EVM
+            block</td>
             </tr>
             <tr class="odd">
             <td><strong>Base Fee Per Gas</strong></td>
-            <td>0.001 gwei (<br /><span class="math display">10<sup>6</sup></span><br /> wei)</td>
+            <td>0.001 gwei (<span
+            class="math display">10<sup>6</sup></span> wei)</td>
             </tr>
             <tr class="even">
             <td><strong>EIP-1559 Parameters</strong></td>
@@ -105,11 +125,17 @@
             </tr>
             </tbody>
             </table>
-            <h2 id="connecting-to-the-testnet">Connecting to the Testnet</h2>
+            <h2 id="connecting-to-the-testnet">Connecting to the
+            Testnet</h2>
             <h3 id="rpc">RPC</h3>
-            <p>MegaETH provides a public endpoint at https://carrot.megaeth.com/rpc. Alchemy sells managed endpoints.</p>
+            <p>MegaETH provides a public endpoint at
+            https://carrot.megaeth.com/rpc. Alchemy sells managed
+            endpoints.</p>
             <h3 id="block-explorer">Block Explorer</h3>
-            <p>Check out <a href="https://megaeth-testnet-v2.blockscout.com/">Blockscout</a> and <a href="https://uptime.megaeth.com">uptime.megaeth.com</a>.</p>
+            <p>Check out <a
+            href="https://megaeth-testnet-v2.blockscout.com/">Blockscout</a>
+            and <a
+            href="https://uptime.megaeth.com">uptime.megaeth.com</a>.</p>
         </main>
 
         <footer class="site-footer">


### PR DESCRIPTION
# Summary
  Add missing L1 proxy addresses to mainnet docs                            
                                                                                                     
  Adds three L1 contract proxy addresses to the "On Ethereum Mainnet" table in the Mainnet page that
  were previously missing:                                                                           

  - DisputeGameFactoryProxy — 0x8546840adf796875cd9aacc5b3b048f6b2c9d563                             
  - ProtocolVersionsProxy — 0x150355311f965af4937fcca526f9df0573fd5b85                               
  - SuperchainConfigProxy — 0x5d0ff601bc8580d8682c0462df55343cb0b99285                               
                                                                                                     
  Also reorders the table alphabetically for consistency.    