### PR TITLE
docs: fix capitalization of dApps in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ MegaETH is a high-performance Ethereum L2 with ~10ms block times and real-time t
         </tr>
         <tr>
             <td><strong>Developer Docs</strong></td>
-            <td>Build dapps on MegaETH — EVM differences, gas model, RPC reference.</td>
+            <td>Build dApps on MegaETH — EVM differences, gas model, RPC reference.</td>
             <td><a href="dev/overview.md">Developer Docs</a></td>
         </tr>
         <tr>


### PR DESCRIPTION
This PR updates the capitalization of "dapps" to "dApps" in docs/README.md to align with standard Web3 industry terminology and improve overall readability.