### PR TITLE
fix: correct debug method availability and remove unsupported 4byteTracer

### DIFF
--- a/docs/dev/send-tx/debugging.md
+++ b/docs/dev/send-tx/debugging.md
@@ -12,7 +12,6 @@ MegaETH provides two ways to debug transactions:
 ## Debug RPC Methods
 
 Standard Ethereum debug methods are available on the public MegaETH RPC endpoint (`https://mainnet.megaeth.com/rpc`) and through managed RPC providers such as [Alchemy](https://www.alchemy.com/).
-Debug methods share the `compute` rate limit tier (200 requests per 10 seconds).
 
 The following methods are supported:
 

--- a/docs/dev/send-tx/debugging.md
+++ b/docs/dev/send-tx/debugging.md
@@ -6,15 +6,15 @@ description: Debug failing transactions on MegaETH — trace with debug_traceTra
 
 MegaETH provides two ways to debug transactions:
 
-1. **`debug_*` RPC methods** — trace transactions via JSON-RPC (requires a managed RPC endpoint)
+1. **`debug_*` RPC methods** — trace transactions via JSON-RPC
 2. **`mega-evme`** — replay or simulate transactions locally with full tracing
 
 ## Debug RPC Methods
 
-Standard Ethereum debug methods — `debug_traceTransaction`, `debug_traceCall`, and `debug_traceBlockByNumber` — are available through managed RPC providers but **not on the public MegaETH RPC endpoint**.
-Use a provider such as [Alchemy](https://www.alchemy.com/) to access them.
+Standard Ethereum debug methods are available on the public MegaETH RPC endpoint (`https://mainnet.megaeth.com/rpc`) and through managed RPC providers such as [Alchemy](https://www.alchemy.com/).
+Debug methods share the `compute` rate limit tier (200 requests per 10 seconds).
 
-The following methods are available through managed providers:
+The following methods are supported:
 
 - **`debug_traceTransaction`** — trace an already-mined transaction by hash
 - **`debug_traceCall`** — simulate and trace a call without broadcasting
@@ -28,7 +28,6 @@ The following methods are available through managed providers:
 | callTracer              | `"callTracer"`          | Nested call tree with inputs, outputs, and gas usage per call                |
 | prestateTracer          | `"prestateTracer"`      | Account state before execution; set `"diffMode": true` for before/after diff |
 | flatCallTracer          | `"flatCallTracer"`      | Parity-style flat list of all calls                                          |
-| 4byteTracer             | `"4byteTracer"`         | Counts function selector usage                                               |
 
 {% hint style="info" %}
 JavaScript tracers are not supported.
@@ -41,7 +40,7 @@ For method parameters, tracer configuration options, and response formats, see t
 [`mega-evme`](https://docs.megaeth.com/mega-evme) is a local CLI tool that uses the open-source [MegaEVM](https://github.com/megaeth-labs/mega-evm) implementation.
 It can perfectly simulate any transaction's behavior on MegaETH, including storage gas, compute gas caps, and resource limits.
 
-Use `mega-evme` when you want full local control over tracing, or when you don't have access to a managed RPC endpoint with debug methods.
+Use `mega-evme` when you want full local control over tracing, deterministic replay, or what-if analysis with transaction overrides.
 
 ### Installation
 


### PR DESCRIPTION
## Summary
- Debug methods (`debug_traceTransaction`, `debug_traceCall`, `debug_traceBlockByNumber`, `debug_traceBlockByHash`) are available on the public MegaETH RPC endpoint — not restricted to managed providers. Updated the docs to reflect this. (Resolves C-001 from auto-audits#2)
- Removed `4byteTracer` from the supported tracers table — it is not handled by MegaETH's debug handler. (Resolves C-002 from auto-audits#2)
- Updated the mega-evme description to remove the outdated "no access to managed RPC" framing.

## Test plan
- [ ] Verify the updated claims match live behavior at `https://mainnet.megaeth.com/rpc`
- [ ] Confirm 4byteTracer is indeed unsupported

---
*This PR was generated by an automated agent.*