### PR TITLE
chore: add CODEOWNERS with global reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global code owners — reviewed on every PR
+* @Troublor @nnsgmsone


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` file with `@Troublor` and `@nnsgmsone` as global code owners.
- Every PR will now automatically request reviews from both owners.

## Test plan
- Verify the CODEOWNERS file is picked up by GitHub on a subsequent PR.

---
*This PR was generated by an automated agent.*