### PR TITLE
docs(node): add Rex5 to validator hardfork schedule and hooks

### DIFF
--- a/docs/node/validator-architecture.md
+++ b/docs/node/validator-architecture.md
@@ -41,10 +41,10 @@ For the file layout (not a runtime artifact), see the schema-shaped sample at [`
 
 Despite the file carrying the full Genesis schema (allocations, gas limit, timestamp, base fee, ...), the validator consumes only two pieces of state from it:
 
-| Derived value     | Source in `config`                    | Use during validation                                                                                                                                                                                                      |
-| ----------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Chain ID          | `chainId`                             | Drives the EVM `CHAINID` opcode and EIP-155 transaction-signature checks.                                                                                                                                                  |
-| Hardfork schedule | `<fork>Block` and `<fork>Time` fields | Activates Ethereum (Cancun, Shanghai, ...), OP-Stack (Ecotone, Granite, Holocene, Isthmus, ...), and MegaETH (MiniRex, MiniRex1, MiniRex2, Rex, Rex1, Rex2, Rex3, Rex4) at their pre-declared block numbers or timestamps. |
+| Derived value     | Source in `config`                    | Use during validation                                                                                                                                                                                                            |
+| ----------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Chain ID          | `chainId`                             | Drives the EVM `CHAINID` opcode and EIP-155 transaction-signature checks.                                                                                                                                                        |
+| Hardfork schedule | `<fork>Block` and `<fork>Time` fields | Activates Ethereum (Cancun, Shanghai, ...), OP-Stack (Ecotone, Granite, Holocene, Isthmus, ...), and MegaETH (MiniRex, MiniRex1, MiniRex2, Rex, Rex1, Rex2, Rex3, Rex4, Rex5) at their pre-declared block numbers or timestamps. |
 
 The genesis `alloc`, `gasLimit`, `baseFeePerGas`, and other initial-state fields are **not** consumed — once the chain has produced a single block, initial state is served by the witness, not by the genesis file.
 
@@ -190,6 +190,7 @@ Two layers run in order:
    - **MiniRex** — deploy the oracle contract and the high-precision timestamp oracle contract.
    - **Rex2** — deploy the keyless-deploy contract.
    - **Rex4** — deploy the access-control contract and the `MegaLimitControl` contract.
+   - **Rex5** — deploy the `SequencerRegistry` contract (`0x6342000000000000000000000000000000000006`) and upgrade the oracle to its dynamic-authority version. When a scheduled system-address or sequencer change is due, an additional pre-block system call to `applyPendingChanges()` is executed.
    - **MiniRex1, MiniRex2, Rex, Rex1, Rex3** — no new system-contract deployments.
      The fork still gates EVM behavior changes; the pre-execution hook list is just empty.
 

--- a/docs/node/validator-architecture.md
+++ b/docs/node/validator-architecture.md
@@ -190,7 +190,8 @@ Two layers run in order:
    - **MiniRex** — deploy the oracle contract and the high-precision timestamp oracle contract.
    - **Rex2** — deploy the keyless-deploy contract.
    - **Rex4** — deploy the access-control contract and the `MegaLimitControl` contract.
-   - **Rex5** — deploy the `SequencerRegistry` contract (`0x6342000000000000000000000000000000000006`) and upgrade the oracle to its dynamic-authority version. When a scheduled system-address or sequencer change is due, an additional pre-block system call to `applyPendingChanges()` is executed.
+   - **Rex5** — deploy the `SequencerRegistry` contract (`0x6342000000000000000000000000000000000006`) and upgrade the oracle to its dynamic-authority version.
+     When a scheduled system-address or sequencer change is due, an additional pre-block system call to `applyPendingChanges()` is executed.
    - **MiniRex1, MiniRex2, Rex, Rex1, Rex3** — no new system-contract deployments.
      The fork still gates EVM behavior changes; the pre-execution hook list is just empty.
 


### PR DESCRIPTION
## Summary

The validator architecture guide was missing the **Rex5** hardfork. This page is meant to track the full MegaETH hardfork schedule and the per-fork pre-execution system-contract hooks, but stopped at Rex4. This brings it up to date now that Rex5 is the active spec.

- Add `Rex5` to the MegaETH hardfork schedule list (`docs/node/validator-architecture.md`).
- Add a `Rex5` entry to the pre-execution system-contract hook list: deployment of the `SequencerRegistry` contract (`0x6342000000000000000000000000000000000006`), the dynamic-authority oracle upgrade, and the additional pre-block `applyPendingChanges()` system call that runs when a scheduled system-address/sequencer change is due.

Sibling pages (`docs/dev/execution/overview.md`, `docs/dev/execution/system-contracts.md`) already cover Rex5 and the `SequencerRegistry` contract; this aligns the validator page with them.

## Test plan

- `mise run lint` (lychee link check, markdownlint, prettier `--check`) — formatting re-aligned the edited Markdown table to satisfy prettier.
- Rendered the page to confirm the new bullet and schedule entry display correctly.

---
*This PR was generated by an automated agent.*