### PR TITLE
feat(pr-review): default model to opus, add opt-in deep multi-agent mode

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -23,6 +23,11 @@ Prompt-bearing actions (`pr-review`, `label-check`, and `issue-triage`) also acc
 
 The `interactive` action does not accept `extra_prompt` because `@claude` is native.
 
+The `pr-review` action additionally accepts:
+
+- `model` - optional, defaults to `opus`. Passed through to `claude --model`. Set another model id to override, or empty to fall through to the Claude Code CLI default (Sonnet class). Note the `opus` default means every consumer runs reviews on Opus out of the box.
+- `review_depth` - optional, defaults to `standard` (single-agent review). Set to `deep` for multi-agent orchestration: the lead agent fans out one sub-agent per review dimension, adversarially verifies each finding, then converges on the same single consolidated review. `deep` costs more tokens and wall-clock, so raise the calling job's `timeout-minutes` (see Concurrency) and prefer gating it per-PR (e.g. a label) rather than enabling it for every review.
+
 ## Per-Repo Conventions
 
 The prompt-bearing actions instruct Claude to read and respect a consumer repo's own agent

--- a/.github/actions/claude-pr-review/action.yml
+++ b/.github/actions/claude-pr-review/action.yml
@@ -19,10 +19,11 @@ inputs:
     description: Additional prompt text appended after the canonical prompt.
   model:
     required: false
-    default: ""
+    default: opus
     description: >
-      Model for the review agent, passed through to `claude --model`. Empty
-      uses the claude-code-action default. Example: `opus`.
+      Model for the review agent, passed through to `claude --model`. Defaults
+      to `opus`; set to another model id to override, or empty to fall through
+      to the claude-code-action / CLI default (Sonnet class).
   review_depth:
     required: false
     default: standard

--- a/.github/actions/claude-pr-review/action.yml
+++ b/.github/actions/claude-pr-review/action.yml
@@ -17,6 +17,21 @@ inputs:
     required: false
     default: ""
     description: Additional prompt text appended after the canonical prompt.
+  model:
+    required: false
+    default: ""
+    description: >
+      Model for the review agent, passed through to `claude --model`. Empty
+      uses the claude-code-action default. Example: `opus`.
+  review_depth:
+    required: false
+    default: standard
+    description: >
+      `standard` = single-agent review (default). `deep` = multi-agent
+      orchestration: the lead agent fans out one sub-agent per review
+      dimension, adversarially verifies each finding, then converges on the
+      same single consolidated review. `deep` costs more tokens and wall-clock;
+      raise the calling job's timeout-minutes accordingly.
 
 runs:
   using: composite
@@ -25,6 +40,8 @@ runs:
       shell: bash
       env:
         EXTRA_ALLOWED_TOOLS: ${{ inputs.extra_allowed_tools }}
+        MODEL: ${{ inputs.model }}
+        REVIEW_DEPTH: ${{ inputs.review_depth }}
       run: |
         set -euo pipefail
 
@@ -33,7 +50,36 @@ runs:
           allowed_tools="${allowed_tools},${EXTRA_ALLOWED_TOOLS}"
         fi
 
+        # Path 1: optional model override (e.g. opus) for a deeper single pass.
+        model_flag=""
+        if [[ -n "$MODEL" ]]; then
+          model_flag="--model $MODEL"
+        fi
+
+        # Path 2: deep mode lets the lead agent spawn sub-agents, so Task must
+        # be allowed; the orchestration directive is injected into the prompt.
+        if [[ "$REVIEW_DEPTH" == "deep" ]]; then
+          allowed_tools="${allowed_tools},Task"
+        fi
+
         echo "allowed_tools=${allowed_tools}" >> "$GITHUB_OUTPUT"
+        echo "model_flag=${model_flag}" >> "$GITHUB_OUTPUT"
+
+        # Emit the depth-specific orchestration preamble as a multi-line output.
+        delim="ORCH_$RANDOM$RANDOM"
+        echo "orchestration<<$delim" >> "$GITHUB_OUTPUT"
+        if [[ "$REVIEW_DEPTH" == "deep" ]]; then
+          cat >> "$GITHUB_OUTPUT" <<'ORCH'
+          REVIEW DEPTH: deep (multi-agent). You are the LEAD reviewer. Run an orchestrated review BEFORE the posting contract below, then deliver exactly one consolidated review.
+
+          Orchestration (do this first):
+          1. Fan out: use the Task tool to spawn one sub-agent per review dimension, in parallel where possible. Default dimensions (skip any irrelevant to the diff): (a) correctness & edge cases; (b) breakage / backward-compat / public-API & wire/consensus impact; (c) tests — presence, determinism, exact-value assertions; (d) design & complexity; (e) docs, logging, and metrics conventions. Give each sub-agent the PR number, the full diff scope, REVIEW.md, and the relevant local guidance, and require it to return a structured finding list: each item as `path:line — [Severity] finding (one-line rationale)`, anchored to RIGHT-side diff lines where possible. Sub-agents discover and rank; they do NOT post anything.
+          2. Merge & dedup: collect all sub-agent findings, drop duplicates and anything already fixed in the diff, and reconcile overlaps across dimensions into one canonical finding.
+          3. Adversarially verify: for each surviving non-trivial finding, spawn a skeptic sub-agent whose job is to REFUTE it against the actual current file contents and diff (default to "refuted" when uncertain). Keep a finding only if it survives refutation; demote or drop the rest. Record the verified set.
+          4. Hand the verified, deduplicated finding set into the standard contract below as your candidate findings. The Phase 4-6 triage, convergence, and single-review posting rules apply UNCHANGED: the lead posts exactly ONE consolidated review for the round. Sub-agents must never post reviews, comments, or replies.
+ORCH
+        fi
+        echo "$delim" >> "$GITHUB_OUTPUT"
 
     - uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1
       with:
@@ -44,9 +90,12 @@ runs:
         claude_args: |
           --allowedTools "${{ steps.compose.outputs.allowed_tools }}"
           --disallowedTools "mcp__github_inline_comment__create_inline_comment"
+          ${{ steps.compose.outputs.model_flag }}
         prompt: |
           REPO: ${{ github.repository }}
           PR NUMBER: ${{ github.event.pull_request.number }}
+
+          ${{ steps.compose.outputs.orchestration }}
 
           Before reviewing, read and respect this repository's own conventions and agent
           instruction files if they exist: REVIEW.md, README.md, CLAUDE.md, AGENTS.md, and any

--- a/.github/actions/claude-pr-review/action.yml
+++ b/.github/actions/claude-pr-review/action.yml
@@ -68,17 +68,20 @@ runs:
 
         # Emit the depth-specific orchestration preamble as a multi-line output.
         delim="ORCH_$RANDOM$RANDOM"
+        # Emit via indented printf rather than a heredoc: a heredoc's closing
+        # delimiter must sit at column 0, which would terminate this YAML block
+        # scalar early and break action-manifest parsing.
         echo "orchestration<<$delim" >> "$GITHUB_OUTPUT"
         if [[ "$REVIEW_DEPTH" == "deep" ]]; then
-          cat >> "$GITHUB_OUTPUT" <<'ORCH'
-          REVIEW DEPTH: deep (multi-agent). You are the LEAD reviewer. Run an orchestrated review BEFORE the posting contract below, then deliver exactly one consolidated review.
-
-          Orchestration (do this first):
-          1. Fan out: use the Task tool to spawn one sub-agent per review dimension, in parallel where possible. Default dimensions (skip any irrelevant to the diff): (a) correctness & edge cases; (b) breakage / backward-compat / public-API & wire/consensus impact; (c) tests — presence, determinism, exact-value assertions; (d) design & complexity; (e) docs, logging, and metrics conventions. Give each sub-agent the PR number, the full diff scope, REVIEW.md, and the relevant local guidance, and require it to return a structured finding list: each item as `path:line — [Severity] finding (one-line rationale)`, anchored to RIGHT-side diff lines where possible. Sub-agents discover and rank; they do NOT post anything.
-          2. Merge & dedup: collect all sub-agent findings, drop duplicates and anything already fixed in the diff, and reconcile overlaps across dimensions into one canonical finding.
-          3. Adversarially verify: for each surviving non-trivial finding, spawn a skeptic sub-agent whose job is to REFUTE it against the actual current file contents and diff (default to "refuted" when uncertain). Keep a finding only if it survives refutation; demote or drop the rest. Record the verified set.
-          4. Hand the verified, deduplicated finding set into the standard contract below as your candidate findings. The Phase 4-6 triage, convergence, and single-review posting rules apply UNCHANGED: the lead posts exactly ONE consolidated review for the round. Sub-agents must never post reviews, comments, or replies.
-ORCH
+          {
+            printf '%s\n' 'REVIEW DEPTH: deep (multi-agent). You are the LEAD reviewer. Run an orchestrated review BEFORE the posting contract below, then deliver exactly one consolidated review.'
+            printf '%s\n' ''
+            printf '%s\n' 'Orchestration (do this first):'
+            printf '%s\n' '1. Fan out: use the Task tool to spawn one sub-agent per review dimension, in parallel where possible. Default dimensions (skip any irrelevant to the diff): (a) correctness and edge cases; (b) breakage / backward-compat / public-API and wire/consensus impact; (c) tests — presence, determinism, exact-value assertions; (d) design and complexity; (e) docs, logging, and metrics conventions. Give each sub-agent the PR number, the full diff scope, REVIEW.md, and the relevant local guidance, and require it to return a structured finding list: each item as path:line — [Severity] finding (one-line rationale), anchored to RIGHT-side diff lines where possible. Sub-agents discover and rank; they do NOT post anything.'
+            printf '%s\n' '2. Merge and dedup: collect all sub-agent findings, drop duplicates and anything already fixed in the diff, and reconcile overlaps across dimensions into one canonical finding.'
+            printf '%s\n' '3. Adversarially verify: for each surviving non-trivial finding, spawn a skeptic sub-agent whose job is to REFUTE it against the actual current file contents and diff (default to refuted when uncertain). Keep a finding only if it survives refutation; demote or drop the rest. Record the verified set.'
+            printf '%s\n' '4. Hand the verified, deduplicated finding set into the standard contract below as your candidate findings. The Phase 4-6 triage, convergence, and single-review posting rules apply UNCHANGED: the lead posts exactly ONE consolidated review for the round. Sub-agents must never post reviews, comments, or replies.'
+          } >> "$GITHUB_OUTPUT"
         fi
         echo "$delim" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## What

Adds two selectable knobs to the centralized `claude-pr-review` action, and raises the default review model to Opus.

### `model` input (default: `opus`)
Pass-through to `claude --model`. **This changes the baseline**: the action previously set no `--model` and fell through to the Claude Code CLI default (Sonnet class). It now defaults to `opus`, so every `@main` consumer runs reviews on Opus on their next PR event — higher per-token cost and longer wall-clock. Set another model id to override, or empty to restore the CLI default.

### `review_depth: deep` (default: `standard`)
Opt-in multi-agent orchestration. The lead agent:
1. fans out one sub-agent per review dimension (correctness, breakage/compat, tests, design/complexity, docs/logging/metrics) via the `Task` tool;
2. merges & dedups findings;
3. spawns a skeptic sub-agent per finding to **adversarially verify** (refute-by-default) before keeping it;
4. converges on the **same single consolidated review** — the existing Phase 4-6 posting contract (one review per round, triage prior threads) is reused unchanged.

`deep` enables the `Task` tool and injects an orchestration preamble. It costs more tokens and wall-clock, so consumers should raise the calling job's `timeout-minutes` and prefer gating it per-PR (e.g. a label).

## Behavior change & rollout

- **`model` default `opus` is an opt-out change for every pinned-`@main` consumer** — they start on Opus with no action on their side. This is intentional (better default review quality), but reviewers should be aware. Consumers wanting the old behavior can pass `model: ""`.
- `review_depth` defaults to `standard`, so the multi-agent path is strictly opt-in.
- README (`.github/actions/README.md`) updated to document both inputs and the new Opus baseline.

## Why deep is not default-on

Defaulting `deep` would multiply token cost (~5-10x, re-run on every `synchronize`), risk CI timeouts and API rate limits across all consumer repos, and add review noise on trivial PRs. Recommended adoption is per-PR (e.g. a `deep-review` label) or size/path-gated, piloted on a few high-value repos first.

## Verification

- Action manifest parses (validated with a real YAML parser after fixing a column-0 heredoc that had broken manifest loading).
- Compose-step outputs verified for `standard`, `standard+model`, and `deep` modes.
- Dogfooded: this PR's own `pr-review` job ran green on the local action and posted a consolidated review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)