### PR TITLE
docs: add Accept Payments developer guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ The site is organized into layers, each targeting a different audience:
 | Layer                   | Directory                                                 | Audience                        | Tone                               |
 | ----------------------- | --------------------------------------------------------- | ------------------------------- | ---------------------------------- |
 | **User Guide**          | `docs/user/`                                              | End users (wallets, DeFi users) | Plain language, no code            |
-| **Developer Docs**      | `docs/dev/`                                               | DApp/contract builders          | Practical guidance, code examples  |
+| **Developer Docs**      | `docs/dev/`                                               | dapp/contract builders          | Practical guidance, code examples  |
 | **Stateless Validator** | `docs/node/`                                              | Node operators                  | Reference, copy-paste commands     |
 | **Specification**       | [mega-evm repo](https://github.com/megaeth-labs/mega-evm) | Protocol implementers, auditors | Normative (MUST/SHALL), exhaustive |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ The site is organized into layers, each targeting a different audience:
 | Layer                   | Directory                                                 | Audience                        | Tone                               |
 | ----------------------- | --------------------------------------------------------- | ------------------------------- | ---------------------------------- |
 | **User Guide**          | `docs/user/`                                              | End users (wallets, DeFi users) | Plain language, no code            |
-| **Developer Docs**      | `docs/dev/`                                               | Dapp/contract builders          | Practical guidance, code examples  |
+| **Developer Docs**      | `docs/dev/`                                               | DApp/contract builders          | Practical guidance, code examples  |
 | **Stateless Validator** | `docs/node/`                                              | Node operators                  | Reference, copy-paste commands     |
 | **Specification**       | [mega-evm repo](https://github.com/megaeth-labs/mega-evm) | Protocol implementers, auditors | Normative (MUST/SHALL), exhaustive |
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -70,6 +70,7 @@ Use these exact forms consistently. Do not alternate between variants.
 | Block type            | mini-block                                                     | miniblock, mini block, MiniBlock                            |
 | Onchain / offchain    | onchain, offchain                                              | on-chain, off-chain, on chain                               |
 | Smart contract        | smart contract                                                 | Smart Contract, smartcontract                               |
+| Decentralized app     | DApp, DApps                                                    | dapp, dApp, Dapp, dapps, dApps                              |
 | Gas dimensions        | compute gas, storage gas                                       | Compute Gas, Storage Gas, Compute gas                       |
 | Spec names            | MiniRex, MiniRex1, MiniRex2, Rex, Rex1, Rex2, Rex3, Rex4, Rex5 | minirex, MINIREX, mini-rex, rex-3                           |
 | State trie            | SALT                                                           | Salt, salt                                                  |

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -70,7 +70,7 @@ Use these exact forms consistently. Do not alternate between variants.
 | Block type            | mini-block                                                     | miniblock, mini block, MiniBlock                            |
 | Onchain / offchain    | onchain, offchain                                              | on-chain, off-chain, on chain                               |
 | Smart contract        | smart contract                                                 | Smart Contract, smartcontract                               |
-| Decentralized app     | DApp, DApps                                                    | dapp, dApp, Dapp, dapps, dApps                              |
+| Decentralized app     | dapp, dapps                                                    | DApp, dApp, Dapp, DApps, dApps                              |
 | Gas dimensions        | compute gas, storage gas                                       | Compute Gas, Storage Gas, Compute gas                       |
 | Spec names            | MiniRex, MiniRex1, MiniRex2, Rex, Rex1, Rex2, Rex3, Rex4, Rex5 | minirex, MINIREX, mini-rex, rex-3                           |
 | State trie            | SALT                                                           | Salt, salt                                                  |

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -39,6 +39,7 @@
 - [Build with AI](dev/build-with-ai.md)
 - [Tooling & Infrastructure](dev/tooling.md)
 - [Verifiable Randomness (VRF)](dev/vrf.md)
+- [Accept Payments](dev/payments.md)
 - [Developer FAQ](dev/faq.md)
 
 ## Node Operation

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -39,7 +39,7 @@
 - [Build with AI](dev/build-with-ai.md)
 - [Tooling & Infrastructure](dev/tooling.md)
 - [Verifiable Randomness (VRF)](dev/vrf.md)
-- [Accept Payments](dev/payments.md)
+- [Onchain Payments](dev/payments.md)
 - [Developer FAQ](dev/faq.md)
 
 ## Node Operation

--- a/docs/dev/AGENTS.md
+++ b/docs/dev/AGENTS.md
@@ -1,6 +1,6 @@
 # Developer Docs — Writing Rules
 
-This layer targets **dapp and contract developers**: people writing Solidity, deploying contracts, and building applications on MegaETH.
+This layer targets **DApp and contract developers**: people writing Solidity, deploying contracts, and building applications on MegaETH.
 They know Ethereum. They write code. They need to understand what's different.
 
 ## Tone & Language
@@ -17,7 +17,7 @@ They know Ethereum. They write code. They need to understand what's different.
 - Gas model guide (dual gas, storage gas, practical estimation)
 - System contract usage (Oracle, Timestamp, KeylessDeploy — with Solidity interfaces and examples)
 - Architecture overview (sequencer, full nodes, provers)
-- Mini-blocks (what they are, how they affect dapps)
+- Mini-blocks (what they are, how they affect DApps)
 - Realtime API (WebSocket subscriptions, enhanced RPC methods)
 - RPC reference (method table, error codes)
 - Developer FAQ (gas estimation, contract deployment, debugging)

--- a/docs/dev/AGENTS.md
+++ b/docs/dev/AGENTS.md
@@ -1,6 +1,6 @@
 # Developer Docs — Writing Rules
 
-This layer targets **DApp and contract developers**: people writing Solidity, deploying contracts, and building applications on MegaETH.
+This layer targets **dapp and contract developers**: people writing Solidity, deploying contracts, and building applications on MegaETH.
 They know Ethereum. They write code. They need to understand what's different.
 
 ## Tone & Language
@@ -17,7 +17,7 @@ They know Ethereum. They write code. They need to understand what's different.
 - Gas model guide (dual gas, storage gas, practical estimation)
 - System contract usage (Oracle, Timestamp, KeylessDeploy — with Solidity interfaces and examples)
 - Architecture overview (sequencer, full nodes, provers)
-- Mini-blocks (what they are, how they affect DApps)
+- Mini-blocks (what they are, how they affect dapps)
 - Realtime API (WebSocket subscriptions, enhanced RPC methods)
 - RPC reference (method table, error codes)
 - Developer FAQ (gas estimation, contract deployment, debugging)

--- a/docs/dev/overview.md
+++ b/docs/dev/overview.md
@@ -28,6 +28,11 @@ See [Gas Estimation](send-tx/gas-estimation.md) for code examples, toolchain con
 MegaETH supports `debug_traceTransaction` and other debug RPC methods (via managed RPC providers), and provides [`mega-evme`](https://docs.megaeth.com/mega-evme) for local transaction replay and simulation.
 See [Debugging Transactions](send-tx/debugging.md) for usage examples and common debugging scenarios.
 
+## Onchain Payments
+
+To charge for access to an API, content, or a metered service, MegaETH dapps can use the HTTP 402 "pay then retry" pattern with the x402 and MPP protocol families.
+See [Onchain Payments](payments.md) for the five concrete payment flows — one-time and pay-as-you-go, user-paid and gas-sponsored — with diagrams and a runnable reference implementation.
+
 ## Using the Canonical Bridge
 
 MegaETH's canonical bridge is the preferred method to bridge Ether (ETH) from Ethereum to MegaETH.
@@ -65,3 +70,4 @@ See [Contracts & Tokens](send-tx/contracts.md#l1-contracts-ethereum) for all L1 
 - [System Contracts](execution/system-contracts.md) — oracle, timestamp, and other system contracts
 - [RPC Reference](read/overview.md) — JSON-RPC methods and error codes
 - [Realtime API](read/realtime-api.md) — WebSocket and real-time RPC extensions
+- [Onchain Payments](payments.md) — charge for APIs, content, or metered services onchain

--- a/docs/dev/overview.md
+++ b/docs/dev/overview.md
@@ -30,7 +30,7 @@ See [Debugging Transactions](send-tx/debugging.md) for usage examples and common
 
 ## Onchain Payments
 
-To charge for access to an API, content, or a metered service, MegaETH dapps can use the HTTP 402 "pay then retry" pattern with the x402 and MPP protocol families.
+To charge for access to an API, content, or a metered service, MegaETH DApps can use the HTTP 402 "pay then retry" pattern with the x402 and MPP protocol families.
 See [Onchain Payments](payments.md) for the five concrete payment flows — one-time and pay-as-you-go, user-paid and gas-sponsored — with diagrams and a runnable reference implementation.
 
 ## Using the Canonical Bridge

--- a/docs/dev/overview.md
+++ b/docs/dev/overview.md
@@ -30,7 +30,7 @@ See [Debugging Transactions](send-tx/debugging.md) for usage examples and common
 
 ## Onchain Payments
 
-To charge for access to an API, content, or a metered service, MegaETH DApps can use the HTTP 402 "pay then retry" pattern with the x402 and MPP protocol families.
+To charge for access to an API, content, or a metered service, MegaETH dapps can use the HTTP 402 "pay then retry" pattern with the x402 and MPP protocol families.
 See [Onchain Payments](payments.md) for the five concrete payment flows — one-time and pay-as-you-go, user-paid and gas-sponsored — with diagrams and a runnable reference implementation.
 
 ## Using the Canonical Bridge

--- a/docs/dev/payments.md
+++ b/docs/dev/payments.md
@@ -6,18 +6,23 @@ description: >-
   worked example.
 ---
 
-# Accept Payments
+# Onchain Payments
 
 This guide shows how to charge for access to an API, a piece of content, or a metered service in a MegaETH dapp.
 It explains the one pattern every approach shares, the two protocol families built on it, and five concrete flows you can pick from.
-All five run against the same MegaETH Testnet token and are implemented end-to-end in the [Payment Demo](https://github.com/megaeth-labs/payment-demo).
 
 {% hint style="info" %}
 For a complete, runnable reference — a Next.js app with a connected wallet, a server-side relayer, the escrow contract, and all five flows side by side — see the [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo).
 This guide explains the mechanisms; the demo is the code.
 {% endhint %}
 
-## The shared idea: HTTP 402
+{% hint style="warning" %}
+**Onchain payments can be reorged.**
+A payment transaction that looks confirmed — a `transfer`, a `permit` settlement, or a channel `close` — can still be rolled back if the chain reorgs, so its receipt is not final the instant you see it.
+Before releasing the paid resource, wait for the level of confirmation your risk tolerance requires rather than trusting a single freshly-seen receipt, and make payment verification **idempotent** so a replayed or re-mined transaction is never double-credited.
+{% endhint %}
+
+## HTTP 402
 
 Every flow in this guide is a variation on the same handshake, built on the long-reserved `402 Payment Required` HTTP status code:
 
@@ -27,54 +32,80 @@ Every flow in this guide is a variation on the same handshake, built on the long
 4. The client retries the same request, carrying **proof of payment**.
 5. The server verifies the proof, serves the resource, and returns a **receipt**.
 
-What changes between flows is only two things: **what counts as proof**, and **who pays the gas**.
+What changes between flows is only two things: **what counts as proof**, and **who pays the gas** for the onchain payment transaction.
 Everything else is the same request/response shape.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as Resource server
+    C->>S: GET /resource (no payment)
+    S-->>C: 402 Payment Required (price, token, recipient)
+    C->>C: pay or sign authorization
+    C->>S: retry GET + proof of payment
+    S->>S: verify proof
+    S-->>C: 200 + resource + receipt
+```
 
 ## Two protocol families
 
-MegaETH dapps have two interoperable-by-pattern (but independent) protocol stacks to choose from.
+DApps have two interoperable-by-pattern (but independent) protocol stacks to choose from (Node.js).
 They both ride on HTTP 402; they are not extensions of each other.
 
-| Family   | Package   | Model it covers                         |
-| -------- | --------- | --------------------------------------- |
-| **x402** | `@x402/*` | One-time payments via a _facilitator_   |
-| **MPP**  | `mppx`    | One-time _and_ pay-as-you-go (channels) |
+| Family                                                              | NPM Package | Model it covers                         |
+| ------------------------------------------------------------------- | ----------- | --------------------------------------- |
+| [**x402**](https://github.com/x402-foundation/x402/tree/main/specs) | `@x402/*`   | One-time payments via a _facilitator_   |
+| [**MPP**](https://mpp.dev/overview)                                 | `mppx`      | One-time _and_ pay-as-you-go (channels) |
 
 Think of them like two payment processors that speak the same wire protocol.
-x402 is a standards-style one-shot paywall; MPP (Machine Payments Protocol) adds streaming/metered billing on top of the same idea.
+x402 is a standards-style one-shot paywall; MPP ([Machine Payments Protocol](https://mpp.dev/overview)) adds streaming/metered billing on top of the same idea.
 
 ## The two axes that organize everything
 
 Before the five flows, hold two questions in your head:
 
 - **One-time or streaming?** Charge once per request, or open a channel and bill many requests cheaply?
-- **Who pays gas?** The end user, or you (the server) sponsoring it so the user only signs?
+- **Who pays gas onchain?** The end user, or you (the server) sponsoring it so the user only signs?
 
 The five flows are just the useful points in that 2×2, plus x402 as the standards-based one-time reference.
 
-| #   | Flow                        | Model         | User only signs? (gasless)  |
-| --- | --------------------------- | ------------- | --------------------------- |
-| 1   | x402 exact                  | one-time      | yes — facilitator sponsors  |
-| 2   | MPP charge (push)           | one-time      | no — user sends the payment |
-| 3   | MPP charge (gasless / pull) | one-time      | yes — server pulls funds    |
-| 4   | MPP session (official)      | pay-as-you-go | no — user funds the channel |
-| 5   | MPP session (gasless)       | pay-as-you-go | yes — server relays funding |
+| #   | Flow                                                                 | Model         | User only signs? (gasless)  |
+| --- | -------------------------------------------------------------------- | ------------- | --------------------------- |
+| 1   | [x402 exact](#flow-1--x402-exact-payment)                            | one-time      | yes — facilitator sponsors  |
+| 2   | [MPP charge (push)](#flow-2--mpp-charge-push-mode)                   | one-time      | no — user sends the payment |
+| 3   | [MPP charge (gasless / pull)](#flow-3--mpp-charge-gasless-pull-mode) | one-time      | yes — server pulls funds    |
+| 4   | [MPP session (official)](#flow-4--mpp-session-pay-as-you-go)         | pay-as-you-go | no — user funds the channel |
+| 5   | [MPP session (gasless)](#flow-5--mpp-session-gasless)                | pay-as-you-go | yes — server relays funding |
 
 ## Flow 1 — x402 exact payment
 
 **Use it for:** a standards-based one-time paywall, with gasless onboarding for first-time users.
+**Official spec:** [x402 `exact` scheme for EVM](https://github.com/x402-foundation/x402/blob/main/specs/schemes/exact/scheme_exact_evm.md).
 
 The server declares a price in a structured challenge.
 The client signs a typed-data payment authorization, and a separate component called a **facilitator** verifies it and settles it onchain.
 The facilitator holds a funded key, so it can submit the settlement transaction and **sponsor the gas** — the user never needs the native gas token for their first payment.
 
-```text
-client ──GET──▶ resource server ──402 (price, token, payTo)──▶ client
-client ──sign Permit2 / EIP-2612 authorization──▶
-client ──retry GET + payment header──▶ resource server
-                         ├─ verify(payload)  ┐
-                         └─ settle(payload)  ┴─▶ facilitator submits onchain tx
-resource server ──200 + content + settlement header──▶ client
+1. The client requests the resource and gets a `402` challenge (price, token, `payTo`).
+2. The client signs a typed-data payment authorization (Permit2 / EIP-2612) — **no gas**.
+3. The client retries the request carrying the payment header.
+4. The resource server hands the payload to the **facilitator**, which verifies and settles it onchain — **the facilitator pays gas**.
+5. The server returns the content plus a settlement header.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as Resource server
+    participant F as Facilitator
+    C->>S: GET /resource
+    S-->>C: 402 (price, token, payTo)
+    C->>C: sign Permit2 / EIP-2612 authorization
+    C->>S: retry GET + payment header
+    S->>F: verify(payload)
+    S->>F: settle(payload)
+    F->>F: submit onchain tx (sponsors gas)
+    F-->>S: settlement result
+    S-->>C: 200 + content + settlement header
 ```
 
 The defining trait is the **facilitator**: the resource server stays thin (it only declares a price and gates content) and delegates all key-holding and onchain work.
@@ -88,6 +119,7 @@ That combination is what makes a brand-new user's first payment fully gasless.
 ## Flow 2 — MPP charge, push mode
 
 **Use it for:** the simplest possible one-time payment, with no server key and no sponsorship.
+**Official spec:** [MPP `charge` intent](https://mpp.dev/intents/charge).
 
 The client just makes the payment itself and shows the receipt.
 This is MPP's official `tempo.charge` intent.
@@ -96,6 +128,20 @@ This is MPP's official `tempo.charge` intent.
 2. The client's wallet sends a normal ERC-20 `transfer(recipient, amount)` — **the user pays gas**.
 3. The client retries with proof: `{ type: "hash", hash }`.
 4. The server verifies that transaction onchain (right token, recipient, amount; one-time-use) and serves the content.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as Resource server
+    participant T as Token (ERC-20)
+    C->>S: GET /resource
+    S-->>C: 402 tempo.charge (amount, token, recipient)
+    C->>T: transfer(recipient, amount) — client pays gas
+    T-->>C: tx hash
+    C->>S: retry GET + proof { type: "hash", hash }
+    S->>T: read receipt (token, recipient, amount, one-time-use)
+    S-->>C: 200 + content + receipt
+```
 
 The only onchain interaction is the user's own transfer.
 The server never sends a transaction — it just reads the receipt — so this flow needs no server private key.
@@ -108,6 +154,7 @@ It is not cryptographically bound to a specific request, so use the optional `me
 ## Flow 3 — MPP charge, gasless (pull) mode
 
 **Use it for:** a one-time charge where the user has no native gas token and should only sign.
+**Official spec:** [MPP `charge` intent](https://mpp.dev/intents/charge) (this gasless pull is a Permit-based variant of it).
 
 Same one-time charge, but the **server pays gas and pulls the funds**.
 The user signs an [EIP-2612](#building-blocks) `permit`; the server submits it and then pulls the payment.
@@ -118,33 +165,68 @@ The user signs an [EIP-2612](#building-blocks) `permit`; the server submits it a
 4. The server verifies the signature, nonce, deadline, amount, and balance.
 5. The server submits `permit(...)` and then `transferFrom(owner, recipient, amount)` — **the server pays gas for both**.
 
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as Resource server
+    participant T as Token (ERC-20)
+    C->>S: GET /resource
+    S-->>C: 402 (spender, token name, version)
+    C->>C: sign Permit(owner, spender, value, nonce, deadline)
+    C->>S: retry GET + signed permit
+    S->>S: verify signature, nonce, deadline, amount, balance
+    S->>T: permit(...) — server pays gas
+    S->>T: transferFrom(owner, recipient, amount) — server pays gas
+    S-->>C: 200 + content + receipt
+```
+
 This is the same user-facing shape as push mode, but the proof is a signature instead of a finished transaction, and settlement moves to the server.
 It requires a funded server key.
+
+{% hint style="info" %}
+The official MPP `charge` intent only standardizes **push mode** (Flow 2), where the user sends and pays for the transfer.
+This gasless pull variant is a **demo extension**: it adds an [EIP-2612](#building-blocks) `permit` + `transferFrom` settlement path so the server can pull the funds and pay the gas.
+It is not part of the official spec.
+{% endhint %}
 
 ## Flow 4 — MPP session (pay-as-you-go)
 
 **Use it for:** high-frequency or metered billing — pay per API call, per inference, per request — where one transaction per payment would be too slow and too expensive.
+**Official spec:** [MPP `session` intent](https://mpp.dev/intents/session).
 
 This is a **unidirectional payment channel**.
-The client deposits once into an onchain escrow, then pays for each request with a cheap **offchain signed voucher** that carries a running total.
-Only three operations touch the chain — `open`, `topUp`, `close` — while the per-request `voucher` is pure signature.
+The client deposits once into an onchain escrow contract, then pays for each request with a cheap **offchain signed voucher** that carries a running total (i.e., accumulated costs).
+Only three moments ever touch the chain — opening the channel, topping it up, and closing it to settle — while paying for each individual request is a pure offchain signature.
+The steps below name the concrete operations: `open`, `topUp`, and `close` are functions on the escrow contract, while the per-request `voucher` is an offchain signature.
 
-```text
-deposit ──open──▶ [escrow holds N]
-  request 1: voucher cumulative = 1   (offchain, no gas)
-  request 2: voucher cumulative = 2   (offchain, no gas)
-  request 3: voucher cumulative = 3   (offchain, no gas)
-close with cumulative = 3 ──▶ payee receives 3, payer refunded N − 3
+1. The client `open`s the channel, depositing `N` into the escrow — **client pays gas**.
+2. For each request, the client signs an offchain `voucher` carrying the new **cumulative** total — **no gas**.
+3. The server serves each request, remembering only the single highest voucher per channel.
+4. When the deposit runs low, the client `topUp`s more — **client pays gas**.
+5. To settle, the server `close`s with the highest voucher; the escrow pays the payee that amount and refunds the rest — **server pays gas**.
+
+```mermaid
+sequenceDiagram
+    participant P as Payer (client)
+    participant E as Escrow
+    participant S as Payee (server)
+    P->>E: open — deposit N (onchain)
+    P-->>S: voucher: cumulative = 1 (offchain, no gas)
+    P-->>S: voucher: cumulative = 2 (offchain, no gas)
+    P-->>S: voucher: cumulative = 3 (offchain, no gas)
+    S->>E: close with cumulative = 3 (onchain)
+    E->>S: pay 3
+    E->>P: refund N − 3
 ```
 
 The four actions:
 
-| Action    | Who acts             | Onchain?          | Purpose                                   |
-| --------- | -------------------- | ----------------- | ----------------------------------------- |
-| `open`    | client funds + signs | yes (client gas)  | deposit, create channel, sign 1st voucher |
-| `voucher` | client signs         | **no** — gas-free | pay for one request                       |
-| `topUp`   | client funds         | yes (client gas)  | add deposit when it runs low              |
-| `close`   | server (payee)       | yes (server gas)  | settle highest voucher, refund the rest   |
+| Action    | Initiated by (pays gas) | Tx recipient                | Fund flow                                                          | Onchain?          | Purpose                                   |
+| --------- | ----------------------- | --------------------------- | ------------------------------------------------------------------ | ----------------- | ----------------------------------------- |
+| `open`    | client                  | escrow contract             | client → escrow (deposit `N`)                                      | yes (client gas)  | deposit, create channel, sign 1st voucher |
+| `voucher` | client (signs only)     | — (sent to server offchain) | none — promises a cumulative amount                                | **no** — gas-free | pay for one request                       |
+| `topUp`   | client                  | escrow contract             | client → escrow (add deposit)                                      | yes (client gas)  | add deposit when it runs low              |
+| `close`   | server (payee)          | escrow contract             | escrow → payee (highest voucher); escrow → payer (refund the rest) | yes (server gas)  | settle highest voucher, refund the rest   |
 
 The key invariant: vouchers carry a **cumulative** total, so the server only ever needs to remember the single highest voucher per channel.
 On `close`, the escrow pays the payee that highest amount and refunds the unused deposit to the payer.
@@ -157,9 +239,42 @@ Use a shared store (not in-process memory) across serverless instances, and guar
 ## Flow 5 — MPP session, gasless
 
 **Use it for:** the same metered billing as Flow 4, but with a zero-gas experience — the user only ever signs.
+**Official spec:** [MPP `session` intent](https://mpp.dev/intents/session) (this gasless variant relays funding via Permit2).
 
 The channel model, vouchers, and `close` are identical to Flow 4.
 The only difference is **who funds the channel onchain**: instead of the client sending `open`/`topUp` transactions, the client signs a **Permit2** authorization and the **server relays** the funding.
+
+1. The client signs a **Permit2** authorization to fund the channel instead of sending `open` — **no gas**.
+2. The server relays it via `openWithPermit2`, opening the channel onchain — **server pays gas**.
+3. For each request, the client signs an offchain cumulative `voucher` — **no gas** (identical to Flow 4).
+4. To add funds, the client signs another Permit2 and the server relays `topUpWithPermit2` — **server pays gas**.
+5. The server `close`s with the highest voucher; the escrow pays the payee and refunds the rest — **server pays gas**.
+
+```mermaid
+sequenceDiagram
+    participant P as Payer (client)
+    participant S as Server (relayer + payee)
+    participant E as Escrow
+    P->>P: sign Permit2 authorization (deposit N)
+    P->>S: send signed Permit2
+    S->>E: openWithPermit2(...) — server pays gas
+    P-->>S: voucher: cumulative = 1 (offchain, no gas)
+    P-->>S: voucher: cumulative = 2 (offchain, no gas)
+    S->>E: close with highest voucher — server pays gas
+    E->>S: pay accepted amount
+    E->>P: refund the rest
+```
+
+The four actions:
+
+| Action             | Initiated by (pays gas)              | Tx recipient                | Fund flow                                                          | Onchain?          | Purpose                                         |
+| ------------------ | ------------------------------------ | --------------------------- | ------------------------------------------------------------------ | ----------------- | ----------------------------------------------- |
+| `openWithPermit2`  | server relays (client signs Permit2) | escrow contract             | client → escrow (deposit `N`, pulled via Permit2)                  | yes (server gas)  | fund + create channel, client signs 1st voucher |
+| `voucher`          | client (signs only)                  | — (sent to server offchain) | none — promises a cumulative amount                                | **no** — gas-free | pay for one request                             |
+| `topUpWithPermit2` | server relays (client signs Permit2) | escrow contract             | client → escrow (add deposit)                                      | yes (server gas)  | add deposit when it runs low                    |
+| `close`            | server (payee)                       | escrow contract             | escrow → payee (highest voucher); escrow → payer (refund the rest) | yes (server gas)  | settle highest voucher, refund the rest         |
+
+The contrast with Flow 4 is only **who sends the funding transaction** — the client signs instead of sending, and the server relays:
 
 | Phase     | Flow 4 (official)           | Flow 5 (gasless)                |
 | --------- | --------------------------- | ------------------------------- |
@@ -169,7 +284,13 @@ The only difference is **who funds the channel onchain**: instead of the client 
 | `close`   | server settles              | server settles (identical)      |
 
 Because a relayer (the server), not the payer, sends the funding transaction, the escrow needs entry points where the payer is authorized by **signature** rather than by being `msg.sender`.
-That is exactly what Permit2 (and EIP-3009) provide, and why the gasless flow uses an escrow variant with `*WithPermit2` funding methods.
+That is exactly what **Permit2** and **EIP-3009** provide, and why the gasless flow uses an escrow variant with signature-authorized funding methods (`*WithPermit2` and `receiveWithAuthorization`).
+
+{% hint style="info" %}
+The official MPP `session` spec defines only the **base escrow**, funded by the client's own `open`/`topUp` transactions — it has **no gasless funding path**.
+This gasless flow is a **demo extension**: the escrow variant adds signature-authorized funding entry points — `*WithPermit2` ([Permit2](#building-blocks)) and `receiveWithAuthorization` ([EIP-3009](#building-blocks)) — so a relayer can fund on the payer's behalf.
+It is not part of the official spec.
+{% endhint %}
 
 ## Choosing a flow
 
@@ -198,14 +319,7 @@ Each lets someone authorize a token movement with a **signature** instead of a p
 - **EIP-3009 `receiveWithAuthorization`** — a token-native signed transfer with arbitrary (non-sequential) nonces, enabling concurrent authorizations. Supported by the escrow as an alternative funding path.
 - **Payment channel + voucher** — an onchain escrow settled by cumulative offchain signatures. The core of Flows 4 and 5.
 
-## MegaETH-specific notes
-
-- **Token.** The demo uses a testnet USD-style ERC-20 (USDm) as the payment asset across all five flows.
-- **Escrow.** The session flows use a `TempoStreamChannel`-style escrow deployed on MegaETH; the gasless variant adds Permit2 / EIP-3009 funding entry points so a relayer can fund on the payer's behalf.
-- **Fast settlement.** Server-side settlement (gasless charge, channel `close`, relayed funding) is submitted via MegaETH's realtime transaction RPC, which returns a receipt synchronously instead of requiring a separate poll. See [`realtime_sendRawTransaction`](read/rpc/realtime_sendRawTransaction.md) and the [Realtime API](read/realtime-api.md).
-- **Gas.** Sponsored flows require a funded server key to pay gas. Estimate gas with `eth_estimateGas` against a MegaETH endpoint rather than computing it manually — see [Gas Estimation](send-tx/gas-estimation.md).
-
-## Reference implementation
+## MegaETH-specific payment demo
 
 The [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo) implements all five flows against MegaETH Testnet, with a connected wallet on the client and a relayer/facilitator on the server.
 
@@ -219,10 +333,17 @@ The [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo) impleme
 
 The repository also includes the escrow contract (`contract/`) and protocol scheme notes (`docs/`) explaining each flow in more detail.
 
+**Notes:**
+
+- **Token.** The demo uses a testnet USD-style ERC-20 (USDm) as the payment asset across all five flows.
+- **Escrow.** The session flows use a `TempoStreamChannel`-style escrow deployed on MegaETH; the gasless variant adds Permit2 / EIP-3009 funding entry points so a relayer can fund on the payer's behalf.
+- **Fast settlement.** Server-side settlement (gasless charge, channel `close`, relayed funding) is submitted via MegaETH's realtime transaction RPC, which returns a receipt synchronously instead of requiring a separate poll. See [`realtime_sendRawTransaction`](read/rpc/realtime_sendRawTransaction.md) and the [Realtime API](read/realtime-api.md).
+- **Gas.** Sponsored flows require a funded server key to pay gas. Estimate gas with `eth_estimateGas` against a MegaETH endpoint rather than computing it manually — see [Gas Estimation](send-tx/gas-estimation.md).
+
 ## Further reading
 
 - [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo) — runnable Next.js app implementing all five flows
-- [x402](https://github.com/x402-foundation/x402) — the x402 protocol and packages
-- [MPP — Machine Payments Protocol](https://mpp.dev) — `charge` and `session` payment methods
+- [x402 specification](https://github.com/x402-foundation/x402/tree/main/specs) — the official x402 protocol spec ([repo and packages](https://github.com/x402-foundation/x402))
+- [MPP specification](https://mpp.dev/overview) — the official Machine Payments Protocol spec, built on the [Payment HTTP authentication scheme](https://paymentauth.org) ([`mppx` SDK](https://github.com/wevm/mppx))
 - [Realtime API](read/realtime-api.md) — synchronous transaction submission on MegaETH
 - [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612) · [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009) · [Permit2](https://github.com/Uniswap/permit2)

--- a/docs/dev/payments.md
+++ b/docs/dev/payments.md
@@ -323,13 +323,13 @@ Each lets someone authorize a token movement with a **signature** instead of a p
 
 The [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo) implements all five flows against MegaETH Testnet, with a connected wallet on the client and a relayer/facilitator on the server.
 
-| Flow | Protected route                      | Demo UI component        |
-| ---- | ------------------------------------ | ------------------------ |
-| 1    | `GET /api/protected`                 | `X402Demo`               |
-| 2    | `GET /api/mpp/charge`                | `MppDemo`                |
-| 3    | `GET /api/mpp/gasless-charge`        | `MppGaslessDemo`         |
-| 4    | `GET\|POST /api/mpp/session`         | `MppOfficialSessionDemo` |
-| 5    | `GET\|POST /api/mpp/session-gasless` | `MppSessionGaslessDemo`  |
+| Flow | Protected route                 | Demo UI component        |
+| ---- | ------------------------------- | ------------------------ |
+| 1    | `GET /api/protected`            | `X402Demo`               |
+| 2    | `GET /api/mpp/charge`           | `MppDemo`                |
+| 3    | `GET /api/mpp/gasless-charge`   | `MppGaslessDemo`         |
+| 4    | `POST /api/mpp/session`         | `MppOfficialSessionDemo` |
+| 5    | `POST /api/mpp/session-gasless` | `MppSessionGaslessDemo`  |
 
 The repository also includes the escrow contract (`contract/`) and protocol scheme notes (`docs/`) explaining each flow in more detail.
 

--- a/docs/dev/payments.md
+++ b/docs/dev/payments.md
@@ -10,7 +10,7 @@ description: >-
 
 This guide shows how to charge for access to an API, a piece of content, or a metered service in a MegaETH dapp.
 It explains the one pattern every approach shares, the two protocol families built on it, and five concrete flows you can pick from.
-All five run against the same MegaETH testnet token and are implemented end-to-end in the [Payment Demo](https://github.com/megaeth-labs/payment-demo).
+All five run against the same MegaETH Testnet token and are implemented end-to-end in the [Payment Demo](https://github.com/megaeth-labs/payment-demo).
 
 {% hint style="info" %}
 For a complete, runnable reference — a Next.js app with a connected wallet, a server-side relayer, the escrow contract, and all five flows side by side — see the [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo).
@@ -126,14 +126,14 @@ It requires a funded server key.
 **Use it for:** high-frequency or metered billing — pay per API call, per inference, per request — where one transaction per payment would be too slow and too expensive.
 
 This is a **unidirectional payment channel**.
-The client deposits once into an onchain escrow, then pays for each request with a cheap **off-chain signed voucher** that carries a running total.
+The client deposits once into an onchain escrow, then pays for each request with a cheap **offchain signed voucher** that carries a running total.
 Only three operations touch the chain — `open`, `topUp`, `close` — while the per-request `voucher` is pure signature.
 
 ```text
 deposit ──open──▶ [escrow holds N]
-  request 1: voucher cumulative = 1   (off-chain, no gas)
-  request 2: voucher cumulative = 2   (off-chain, no gas)
-  request 3: voucher cumulative = 3   (off-chain, no gas)
+  request 1: voucher cumulative = 1   (offchain, no gas)
+  request 2: voucher cumulative = 2   (offchain, no gas)
+  request 3: voucher cumulative = 3   (offchain, no gas)
 close with cumulative = 3 ──▶ payee receives 3, payer refunded N − 3
 ```
 
@@ -165,7 +165,7 @@ The only difference is **who funds the channel onchain**: instead of the client 
 | --------- | --------------------------- | ------------------------------- |
 | `open`    | client calls escrow `open`  | server calls `openWithPermit2`  |
 | `topUp`   | client calls escrow `topUp` | server calls `topUpWithPermit2` |
-| `voucher` | off-chain signature         | off-chain signature (identical) |
+| `voucher` | offchain signature          | offchain signature (identical)  |
 | `close`   | server settles              | server settles (identical)      |
 
 Because a relayer (the server), not the payer, sends the funding transaction, the escrow needs entry points where the payer is authorized by **signature** rather than by being `msg.sender`.
@@ -196,7 +196,7 @@ Each lets someone authorize a token movement with a **signature** instead of a p
 - **EIP-2612 `permit`** — a token-native signed approval (`Permit(owner, spender, value, nonce, deadline)`). Works only if the token implements it. Used in Flows 1 and 3.
 - **Permit2** — a single canonical contract (deployed at the same address on every chain) that adds signature-based transfers to _any_ ERC-20 after a one-time `approve(Permit2)`. Its **witness** data binds an authorization to specific terms, preventing reuse on a different channel. Used in Flows 1 and 5.
 - **EIP-3009 `receiveWithAuthorization`** — a token-native signed transfer with arbitrary (non-sequential) nonces, enabling concurrent authorizations. Supported by the escrow as an alternative funding path.
-- **Payment channel + voucher** — an onchain escrow settled by cumulative off-chain signatures. The core of Flows 4 and 5.
+- **Payment channel + voucher** — an onchain escrow settled by cumulative offchain signatures. The core of Flows 4 and 5.
 
 ## MegaETH-specific notes
 
@@ -207,7 +207,7 @@ Each lets someone authorize a token movement with a **signature** instead of a p
 
 ## Reference implementation
 
-The [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo) implements all five flows against MegaETH testnet, with a connected wallet on the client and a relayer/facilitator on the server.
+The [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo) implements all five flows against MegaETH Testnet, with a connected wallet on the client and a relayer/facilitator on the server.
 
 | Flow | Protected route                      | Demo UI component        |
 | ---- | ------------------------------------ | ------------------------ |

--- a/docs/dev/payments.md
+++ b/docs/dev/payments.md
@@ -325,7 +325,7 @@ The [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo) impleme
 
 | Flow | Protected route                 | Demo UI component        |
 | ---- | ------------------------------- | ------------------------ |
-| 1    | `GET /api/protected`            | `X402Demo`               |
+| 1    | `GET /api/x402/exact`           | `X402Demo`               |
 | 2    | `GET /api/mpp/charge`           | `MppDemo`                |
 | 3    | `GET /api/mpp/gasless-charge`   | `MppGaslessDemo`         |
 | 4    | `POST /api/mpp/session`         | `MppOfficialSessionDemo` |

--- a/docs/dev/payments.md
+++ b/docs/dev/payments.md
@@ -49,7 +49,7 @@ sequenceDiagram
 
 ## Two protocol families
 
-DApps have two interoperable-by-pattern (but independent) protocol stacks to choose from (Node.js).
+Dapps have two interoperable-by-pattern (but independent) protocol stacks to choose from, each with a Node.js SDK.
 They both ride on HTTP 402; they are not extensions of each other.
 
 | Family                                                              | NPM Package | Model it covers                         |

--- a/docs/dev/payments.md
+++ b/docs/dev/payments.md
@@ -1,0 +1,228 @@
+---
+description: >-
+  How to accept onchain payments in a MegaETH dapp — the HTTP 402 "pay then
+  retry" pattern, the x402 and MPP protocol families, and five concrete payment
+  flows (one-time and pay-as-you-go, user-paid and gas-sponsored) with a full
+  worked example.
+---
+
+# Accept Payments
+
+This guide shows how to charge for access to an API, a piece of content, or a metered service in a MegaETH dapp.
+It explains the one pattern every approach shares, the two protocol families built on it, and five concrete flows you can pick from.
+All five run against the same MegaETH testnet token and are implemented end-to-end in the [Payment Demo](https://github.com/megaeth-labs/payment-demo).
+
+{% hint style="info" %}
+For a complete, runnable reference — a Next.js app with a connected wallet, a server-side relayer, the escrow contract, and all five flows side by side — see the [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo).
+This guide explains the mechanisms; the demo is the code.
+{% endhint %}
+
+## The shared idea: HTTP 402
+
+Every flow in this guide is a variation on the same handshake, built on the long-reserved `402 Payment Required` HTTP status code:
+
+1. The client requests a protected resource with no payment.
+2. The server replies `402 Payment Required` with a machine-readable **challenge** describing the price, the token, and the recipient.
+3. The client satisfies the challenge — by paying, or by signing an authorization.
+4. The client retries the same request, carrying **proof of payment**.
+5. The server verifies the proof, serves the resource, and returns a **receipt**.
+
+What changes between flows is only two things: **what counts as proof**, and **who pays the gas**.
+Everything else is the same request/response shape.
+
+## Two protocol families
+
+MegaETH dapps have two interoperable-by-pattern (but independent) protocol stacks to choose from.
+They both ride on HTTP 402; they are not extensions of each other.
+
+| Family   | Package   | Model it covers                         |
+| -------- | --------- | --------------------------------------- |
+| **x402** | `@x402/*` | One-time payments via a _facilitator_   |
+| **MPP**  | `mppx`    | One-time _and_ pay-as-you-go (channels) |
+
+Think of them like two payment processors that speak the same wire protocol.
+x402 is a standards-style one-shot paywall; MPP (Machine Payments Protocol) adds streaming/metered billing on top of the same idea.
+
+## The two axes that organize everything
+
+Before the five flows, hold two questions in your head:
+
+- **One-time or streaming?** Charge once per request, or open a channel and bill many requests cheaply?
+- **Who pays gas?** The end user, or you (the server) sponsoring it so the user only signs?
+
+The five flows are just the useful points in that 2×2, plus x402 as the standards-based one-time reference.
+
+| #   | Flow                        | Model         | User only signs? (gasless)  |
+| --- | --------------------------- | ------------- | --------------------------- |
+| 1   | x402 exact                  | one-time      | yes — facilitator sponsors  |
+| 2   | MPP charge (push)           | one-time      | no — user sends the payment |
+| 3   | MPP charge (gasless / pull) | one-time      | yes — server pulls funds    |
+| 4   | MPP session (official)      | pay-as-you-go | no — user funds the channel |
+| 5   | MPP session (gasless)       | pay-as-you-go | yes — server relays funding |
+
+## Flow 1 — x402 exact payment
+
+**Use it for:** a standards-based one-time paywall, with gasless onboarding for first-time users.
+
+The server declares a price in a structured challenge.
+The client signs a typed-data payment authorization, and a separate component called a **facilitator** verifies it and settles it onchain.
+The facilitator holds a funded key, so it can submit the settlement transaction and **sponsor the gas** — the user never needs the native gas token for their first payment.
+
+```text
+client ──GET──▶ resource server ──402 (price, token, payTo)──▶ client
+client ──sign Permit2 / EIP-2612 authorization──▶
+client ──retry GET + payment header──▶ resource server
+                         ├─ verify(payload)  ┐
+                         └─ settle(payload)  ┴─▶ facilitator submits onchain tx
+resource server ──200 + content + settlement header──▶ client
+```
+
+The defining trait is the **facilitator**: the resource server stays thin (it only declares a price and gates content) and delegates all key-holding and onchain work.
+The demo runs the facilitator in-process by default, but it can also be a remote service.
+
+{% hint style="success" %}
+x402's gas sponsoring pairs **Permit2** (the transfer rail) with an **EIP-2612 signature** (to set up the Permit2 allowance without a separate gas-paid `approve`).
+That combination is what makes a brand-new user's first payment fully gasless.
+{% endhint %}
+
+## Flow 2 — MPP charge, push mode
+
+**Use it for:** the simplest possible one-time payment, with no server key and no sponsorship.
+
+The client just makes the payment itself and shows the receipt.
+This is MPP's official `tempo.charge` intent.
+
+1. The client requests the resource and gets a `tempo.charge` challenge (amount, token, recipient).
+2. The client's wallet sends a normal ERC-20 `transfer(recipient, amount)` — **the user pays gas**.
+3. The client retries with proof: `{ type: "hash", hash }`.
+4. The server verifies that transaction onchain (right token, recipient, amount; one-time-use) and serves the content.
+
+The only onchain interaction is the user's own transfer.
+The server never sends a transaction — it just reads the receipt — so this flow needs no server private key.
+
+{% hint style="warning" %}
+Push proof is a transaction hash, validated by amount + recipient + one-time-use.
+It is not cryptographically bound to a specific request, so use the optional `memo`/`expires` fields (or per-request recipients) if you need tight request-to-payment binding.
+{% endhint %}
+
+## Flow 3 — MPP charge, gasless (pull) mode
+
+**Use it for:** a one-time charge where the user has no native gas token and should only sign.
+
+Same one-time charge, but the **server pays gas and pulls the funds**.
+The user signs an [EIP-2612](#building-blocks) `permit`; the server submits it and then pulls the payment.
+
+1. The challenge tells the client the spender, token name, and version.
+2. The client reads the token nonce and signs `Permit(owner, spender, value, nonce, deadline)`.
+3. The client sends the signed permit as proof.
+4. The server verifies the signature, nonce, deadline, amount, and balance.
+5. The server submits `permit(...)` and then `transferFrom(owner, recipient, amount)` — **the server pays gas for both**.
+
+This is the same user-facing shape as push mode, but the proof is a signature instead of a finished transaction, and settlement moves to the server.
+It requires a funded server key.
+
+## Flow 4 — MPP session (pay-as-you-go)
+
+**Use it for:** high-frequency or metered billing — pay per API call, per inference, per request — where one transaction per payment would be too slow and too expensive.
+
+This is a **unidirectional payment channel**.
+The client deposits once into an onchain escrow, then pays for each request with a cheap **off-chain signed voucher** that carries a running total.
+Only three operations touch the chain — `open`, `topUp`, `close` — while the per-request `voucher` is pure signature.
+
+```text
+deposit ──open──▶ [escrow holds N]
+  request 1: voucher cumulative = 1   (off-chain, no gas)
+  request 2: voucher cumulative = 2   (off-chain, no gas)
+  request 3: voucher cumulative = 3   (off-chain, no gas)
+close with cumulative = 3 ──▶ payee receives 3, payer refunded N − 3
+```
+
+The four actions:
+
+| Action    | Who acts             | Onchain?          | Purpose                                   |
+| --------- | -------------------- | ----------------- | ----------------------------------------- |
+| `open`    | client funds + signs | yes (client gas)  | deposit, create channel, sign 1st voucher |
+| `voucher` | client signs         | **no** — gas-free | pay for one request                       |
+| `topUp`   | client funds         | yes (client gas)  | add deposit when it runs low              |
+| `close`   | server (payee)       | yes (server gas)  | settle highest voucher, refund the rest   |
+
+The key invariant: vouchers carry a **cumulative** total, so the server only ever needs to remember the single highest voucher per channel.
+On `close`, the escrow pays the payee that highest amount and refunds the unused deposit to the payer.
+
+{% hint style="danger" %}
+The server settles on the highest voucher it has accepted, so that per-channel state must be **durable and concurrency-safe** in production.
+Use a shared store (not in-process memory) across serverless instances, and guard the voucher update with an atomic compare-and-swap so concurrent requests on one channel cannot be double-served.
+{% endhint %}
+
+## Flow 5 — MPP session, gasless
+
+**Use it for:** the same metered billing as Flow 4, but with a zero-gas experience — the user only ever signs.
+
+The channel model, vouchers, and `close` are identical to Flow 4.
+The only difference is **who funds the channel onchain**: instead of the client sending `open`/`topUp` transactions, the client signs a **Permit2** authorization and the **server relays** the funding.
+
+| Phase     | Flow 4 (official)           | Flow 5 (gasless)                |
+| --------- | --------------------------- | ------------------------------- |
+| `open`    | client calls escrow `open`  | server calls `openWithPermit2`  |
+| `topUp`   | client calls escrow `topUp` | server calls `topUpWithPermit2` |
+| `voucher` | off-chain signature         | off-chain signature (identical) |
+| `close`   | server settles              | server settles (identical)      |
+
+Because a relayer (the server), not the payer, sends the funding transaction, the escrow needs entry points where the payer is authorized by **signature** rather than by being `msg.sender`.
+That is exactly what Permit2 (and EIP-3009) provide, and why the gasless flow uses an escrow variant with `*WithPermit2` funding methods.
+
+## Choosing a flow
+
+Start from the two axes:
+
+| If you need…                                     | Use           |
+| ------------------------------------------------ | ------------- |
+| A standards-based one-time paywall               | Flow 1 (x402) |
+| The simplest one-time charge, no server key      | Flow 2        |
+| A one-time charge with zero gas for the user     | Flow 3        |
+| Metered/streaming billing, user pays gas         | Flow 4        |
+| Metered/streaming billing, zero gas for the user | Flow 5        |
+
+{% hint style="success" %}
+Gasless flows (1, 3, 5) trade a little server cost and a funded relayer key for a much smoother user experience: the user never needs the native gas token and only signs.
+Non-gasless flows (2, 4) are simpler to operate because the user pays their own gas.
+{% endhint %}
+
+## Building blocks
+
+These primitives recur across the flows.
+Each lets someone authorize a token movement with a **signature** instead of a pre-sent `approve` transaction — the foundation of every gasless flow.
+
+- **EIP-2612 `permit`** — a token-native signed approval (`Permit(owner, spender, value, nonce, deadline)`). Works only if the token implements it. Used in Flows 1 and 3.
+- **Permit2** — a single canonical contract (deployed at the same address on every chain) that adds signature-based transfers to _any_ ERC-20 after a one-time `approve(Permit2)`. Its **witness** data binds an authorization to specific terms, preventing reuse on a different channel. Used in Flows 1 and 5.
+- **EIP-3009 `receiveWithAuthorization`** — a token-native signed transfer with arbitrary (non-sequential) nonces, enabling concurrent authorizations. Supported by the escrow as an alternative funding path.
+- **Payment channel + voucher** — an onchain escrow settled by cumulative off-chain signatures. The core of Flows 4 and 5.
+
+## MegaETH-specific notes
+
+- **Token.** The demo uses a testnet USD-style ERC-20 (USDm) as the payment asset across all five flows.
+- **Escrow.** The session flows use a `TempoStreamChannel`-style escrow deployed on MegaETH; the gasless variant adds Permit2 / EIP-3009 funding entry points so a relayer can fund on the payer's behalf.
+- **Fast settlement.** Server-side settlement (gasless charge, channel `close`, relayed funding) is submitted via MegaETH's realtime transaction RPC, which returns a receipt synchronously instead of requiring a separate poll. See [`realtime_sendRawTransaction`](read/rpc/realtime_sendRawTransaction.md) and the [Realtime API](read/realtime-api.md).
+- **Gas.** Sponsored flows require a funded server key to pay gas. Estimate gas with `eth_estimateGas` against a MegaETH endpoint rather than computing it manually — see [Gas Estimation](send-tx/gas-estimation.md).
+
+## Reference implementation
+
+The [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo) implements all five flows against MegaETH testnet, with a connected wallet on the client and a relayer/facilitator on the server.
+
+| Flow | Protected route                      | Demo UI component        |
+| ---- | ------------------------------------ | ------------------------ |
+| 1    | `GET /api/protected`                 | `X402Demo`               |
+| 2    | `GET /api/mpp/charge`                | `MppDemo`                |
+| 3    | `GET /api/mpp/gasless-charge`        | `MppGaslessDemo`         |
+| 4    | `GET\|POST /api/mpp/session`         | `MppOfficialSessionDemo` |
+| 5    | `GET\|POST /api/mpp/session-gasless` | `MppSessionGaslessDemo`  |
+
+The repository also includes the escrow contract (`contract/`) and protocol scheme notes (`docs/`) explaining each flow in more detail.
+
+## Further reading
+
+- [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo) — runnable Next.js app implementing all five flows
+- [x402](https://github.com/x402-foundation/x402) — the x402 protocol and packages
+- [MPP — Machine Payments Protocol](https://mpp.dev) — `charge` and `session` payment methods
+- [Realtime API](read/realtime-api.md) — synchronous transaction submission on MegaETH
+- [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612) · [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009) · [Permit2](https://github.com/Uniswap/permit2)

--- a/docs/dev/payments.md
+++ b/docs/dev/payments.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  How to accept onchain payments in a MegaETH DApp — the HTTP 402 "pay then
+  How to accept onchain payments in a MegaETH dapp — the HTTP 402 "pay then
   retry" pattern, the x402 and MPP protocol families, and five concrete payment
   flows (one-time and pay-as-you-go, user-paid and gas-sponsored) with a full
   worked example.
@@ -8,11 +8,11 @@ description: >-
 
 # Onchain Payments
 
-This guide shows how to charge for access to an API, a piece of content, or a metered service in a MegaETH DApp.
+This guide shows how to charge for access to an API, a piece of content, or a metered service in a MegaETH dapp.
 It explains the one pattern every approach shares, the two protocol families built on it, and five concrete flows you can pick from.
 
 {% hint style="info" %}
-For a complete, runnable reference — a Next.js app with a connected wallet, a server-side relayer, the escrow contract, and all five flows side by side — see the [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo).
+All five flows run against the same MegaETH Testnet token and are implemented end-to-end in the [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo).
 This guide explains the mechanisms; the demo is the code.
 {% endhint %}
 
@@ -49,7 +49,7 @@ sequenceDiagram
 
 ## Two protocol families
 
-DApps have two interoperable-by-pattern (but independent) protocol stacks to choose from, each with a Node.js SDK.
+For dapps, there are two interoperable-by-pattern (but independent) protocol stacks to choose from, each with a Node.js SDK.
 They both ride on HTTP 402; they are not extensions of each other.
 
 | Family                                                              | NPM Package | Model it covers                         |

--- a/docs/dev/payments.md
+++ b/docs/dev/payments.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  How to accept onchain payments in a MegaETH dapp — the HTTP 402 "pay then
+  How to accept onchain payments in a MegaETH DApp — the HTTP 402 "pay then
   retry" pattern, the x402 and MPP protocol families, and five concrete payment
   flows (one-time and pay-as-you-go, user-paid and gas-sponsored) with a full
   worked example.
@@ -8,7 +8,7 @@ description: >-
 
 # Onchain Payments
 
-This guide shows how to charge for access to an API, a piece of content, or a metered service in a MegaETH dapp.
+This guide shows how to charge for access to an API, a piece of content, or a metered service in a MegaETH DApp.
 It explains the one pattern every approach shares, the two protocol families built on it, and five concrete flows you can pick from.
 
 {% hint style="info" %}
@@ -49,7 +49,7 @@ sequenceDiagram
 
 ## Two protocol families
 
-Dapps have two interoperable-by-pattern (but independent) protocol stacks to choose from, each with a Node.js SDK.
+DApps have two interoperable-by-pattern (but independent) protocol stacks to choose from, each with a Node.js SDK.
 They both ride on HTTP 402; they are not extensions of each other.
 
 | Family                                                              | NPM Package | Model it covers                         |

--- a/docs/node/AGENTS.md
+++ b/docs/node/AGENTS.md
@@ -24,7 +24,7 @@ Readers are comfortable on the Linux command line, know how to read a systemd un
 ## What Does NOT Belong Here
 
 - End-user wallet or bridging instructions → `docs/user/`.
-- DApp / contract developer guidance → `docs/dev/`.
+- dapp / contract developer guidance → `docs/dev/`.
 - Normative protocol specification → [mega-evm repo](https://github.com/megaeth-labs/mega-evm).
 - Internal architecture of the validator crate (module layout, trait design) → the upstream repo README.
 

--- a/docs/node/AGENTS.md
+++ b/docs/node/AGENTS.md
@@ -24,7 +24,7 @@ Readers are comfortable on the Linux command line, know how to read a systemd un
 ## What Does NOT Belong Here
 
 - End-user wallet or bridging instructions → `docs/user/`.
-- Dapp / contract developer guidance → `docs/dev/`.
+- DApp / contract developer guidance → `docs/dev/`.
 - Normative protocol specification → [mega-evm repo](https://github.com/megaeth-labs/mega-evm).
 - Internal architecture of the validator crate (module layout, trait design) → the upstream repo README.
 


### PR DESCRIPTION
## Summary

- Adds `docs/dev/payments.md` — a developer guide for accepting onchain payments in a MegaETH dapp.
- Explains the shared **HTTP 402 "pay then retry"** pattern, the two protocol families (**x402** and **MPP**), and the two axes (one-time vs pay-as-you-go; user-paid vs gas-sponsored).
- Walks through the **five payment flows** in developer-friendly terms: x402 exact, MPP charge (push), MPP charge (gasless/pull), MPP session (official), and MPP session (gasless) — with flow diagrams, when-to-use guidance, and the building blocks (EIP-2612, Permit2, EIP-3009, payment channels/vouchers).
- References the [MegaETH Payment Demo](https://github.com/megaeth-labs/payment-demo) as the runnable reference implementation, with a route/component map per flow.
- Adds the page to `docs/SUMMARY.md` under Developer Docs.

## Test plan

- `mise run lint` — `markdownlint-cli2` passes (0 errors); `prettier --check` passes; internal links + the same-file anchor validate with lychee (42 OK, 0 errors; external URLs excluded by `offline`).
- Follows `docs/dev/AGENTS.md` conventions: YAML `description` frontmatter, one-sentence-per-line, GitBook `{% hint %}` blocks, relative `.md` links, language-tagged code blocks.

---
*This PR was generated by an automated agent.*