### PR TITLE
Sami/update testnet explorer

### DIFF
--- a/docs/.gitbook/vars.yaml
+++ b/docs/.gitbook/vars.yaml
@@ -7,6 +7,7 @@ testnet_rpc: https://carrot.megaeth.com/rpc
 mainnet_blockscout: https://megaeth.blockscout.com
 mainnet_etherscan: https://mega.etherscan.io
 testnet_blockscout: https://megaeth-testnet-v2.blockscout.com
+testnet_etherscan: https://testnet-mega.etherscan.io
 network_status: https://uptime.megaeth.com
 mainnet_bridge: '0x0CA3A2FBC3D770b578223FBB6b062fa875a2eE75'
 block_gas_limit: 10,000,000,000

--- a/docs/user/get-started.md
+++ b/docs/user/get-started.md
@@ -32,7 +32,7 @@ In MetaMask, Rabby, or any Ethereum-compatible wallet, go to **Settings → Netw
 | **RPC URL** | <code class="expression">space.vars.testnet_rpc</code> |
 | **Chain ID** | <code class="expression">space.vars.testnet_chain_id</code> |
 | **Currency Symbol** | ETH |
-| **Block Explorer** | <code class="expression">space.vars.testnet_blockscout</code> |
+| **Block Explorer** | <code class="expression">space.vars.testnet_etherscan</code> |
 {% endtab %}
 {% endtabs %}
 


### PR DESCRIPTION
blockscout testnet explorer is being deprecated on Jul 10 so I've replaced mentions of it with the etherscan explorer 