### PR TITLE
ci: pin default Claude review model to claude-opus-4-7

### DIFF
--- a/.github/actions/claude-pr-review/action.yml
+++ b/.github/actions/claude-pr-review/action.yml
@@ -19,11 +19,12 @@ inputs:
     description: Additional prompt text appended after the canonical prompt.
   model:
     required: false
-    default: opus
+    default: claude-opus-4-7
     description: >
-      Model for the review agent, passed through to `claude --model`. Defaults
-      to `opus`; set to another model id to override, or empty to fall through
-      to the claude-code-action / CLI default (Sonnet class).
+      Model for the review agent, passed through to `claude --model`. Pinned to
+      `claude-opus-4-7` so reviews stay on a fixed model rather than following
+      the moving `opus` alias; set to another model id to override, or empty to
+      fall through to the claude-code-action / CLI default (Sonnet class).
   review_depth:
     required: false
     default: standard


### PR DESCRIPTION
## Summary
- The `claude-pr-review` composite action's `model` input defaulted to the `opus` alias, which resolves to whatever the latest Opus model is at run time (currently Opus 4.8). Every consuming repo (mega-reth, mega-evm, mega-e2e, mega-agents, mega-devops, dist-docs, watchdog-rpc, documentation) inherits this default.
- This pins the default to `claude-opus-4-7` so PR reviews run on a fixed, predictable model instead of silently shifting when the alias advances to a new Opus release.
- Callers can still override via the `model` input, or set it empty to fall through to the claude-code-action / CLI default.

## Test plan
- Change is limited to the `default:` value and description of the `model` input in `.github/actions/claude-pr-review/action.yml`; the composite action logic is unchanged.
- The value is passed straight through to `claude --model`; `claude-opus-4-7` is a valid model id (hyphenated form the CLI expects).
- Verifiable on the next PR review run: the review agent job should invoke `--model claude-opus-4-7`.

---
*This PR was generated by an automated agent.*