### PR TITLE
docs(dev/tooling): reference OpenChainBench for third-party MegaETH RPC comparison

### DIFF
--- a/docs/dev/tooling.md
+++ b/docs/dev/tooling.md
@@ -25,6 +25,8 @@ description: Developer tooling and infrastructure partners on MegaETH — RPC pr
 | Envio HyperRPC | HTTP _(read-only)_ | [Docs](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc)    | `https://megaeth.rpc.hypersync.xyz`                       | Supported |
 | Chainstack     | HTTP               | [Docs](https://chainstack.com/build-better-with-megaeth/)         | No public endpoint (API key required)                     | Supported |
 
+For an independent third-party comparison of the MegaETH RPC providers listed above, see the [OpenChainBench MegaETH RPC benchmark](https://openchainbench.com/benchmarks/megaeth-rpc). Latency (p50/p95/p99), reliability, and stale-block detection are probed every minute from three regions (US East, EU West, Singapore) and published under a CC BY 4.0 license alongside the open-source Go harness.
+
 ---
 
 ## Explorers


### PR DESCRIPTION
## Summary

Adds a short paragraph directly under the RPC Providers table in `docs/dev/tooling.md`, pointing readers to the [OpenChainBench MegaETH RPC benchmark](https://openchainbench.com/benchmarks/megaeth-rpc) as an independent third-party latency and reliability comparison of the MegaETH RPC providers listed in the table.

## Why it fits

The current RPC Providers table lists 10 providers (MegaETH Official, Alchemy, QuickNode, Nirvana Labs, dRPC, GlobalStake, Liquify, Dwellir, Envio HyperRPC, Chainstack). Each provider publishes its own performance claims. Given MegaETH's real-time latency positioning (~10ms block times), builders picking an RPC endpoint benefit from a neutral third-party comparison across the same request pattern.

OpenChainBench probes the MegaETH endpoints every minute from three regions (US East, EU West, Singapore), publishes p50/p95/p99 latency, reliability classification, and stale-block detection. Data ships under a CC BY 4.0 license and the Go harness is open source on GitHub. OpenChainBench has no affiliation with any of the listed providers or MegaETH Labs.

## Change

One added paragraph directly after the RPC Providers table. No changes to the table itself or any other section.

## Disclosure

I am the maintainer of OpenChainBench. Happy to reword, shorten, or drop the reference entirely if it does not fit the docs style guide.