### PR TITLE
doc: correct mega_getBlockWitness error codes and coverage

### DIFF
--- a/docs/node/debug-trace-server.md
+++ b/docs/node/debug-trace-server.md
@@ -39,7 +39,8 @@ The server needs two upstream endpoints to operate:
 
 {% hint style="info" %}
 Most external teams do not run their own witness generator.
-Point `--witness-endpoint` at the MegaETH public RPC — it serves `mega_getBlockWitness` for all historical blocks.
+Point `--witness-endpoint` at the MegaETH public RPC — it serves `mega_getBlockWitness` for all historical blocks on mainnet.
+On testnet, witnesses are only available for block `1000` and blocks `>= 10325789` — see [Historical coverage](witness.md#historical-coverage).
 In the common case both flags point to the same URL.
 {% endhint %}
 

--- a/docs/node/witness.md
+++ b/docs/node/witness.md
@@ -97,20 +97,21 @@ The response `result` is a single string of the form `<version>:<base64-payload>
 | `-32602` | Invalid params — malformed JSON, missing `blockNumber`, unparseable hex, or an invalid parameter combination. |
 | `-32603` | Witness not found for the requested keys, or a server-side failure while fetching it.                         |
 
-A missing witness and a server-side fetch failure both surface as `-32603`; the error `message` (for example `Witness not found`) distinguishes them.
-Note that `Witness not found` can be an expected outcome, not an error condition — see [Historical coverage](#historical-coverage) below.
+A missing witness and a server-side fetch failure both surface as `-32603`; the error `message` distinguishes them.
+To treat a missing witness as an expected outcome, match both `code == -32603` and an error `message` containing `Witness not found`.
+Treating `-32603` alone as a hard failure produces false alerts for testnet blocks outside the covered range — see [Historical coverage](#historical-coverage) below.
 The RPC layer in front of the witness service may also return standard JSON-RPC transport codes: `-32700` (parse error), `-32600` (invalid request).
 
 ### Historical coverage
 
 Witness availability on the public RPC depends on the network:
 
-| Network | Coverage                                                                                                                                           |
-| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Mainnet | All blocks.                                                                                                                                        |
-| Testnet | Block `1000` (a permanent test fixture) and blocks `>= 10325789`. Older testnet witnesses are at best sparsely available and cannot be backfilled. |
+| Network | Coverage                                                                                                                                                 |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mainnet | All blocks.                                                                                                                                              |
+| Testnet | As of 2026-07-24: block `1000` (a permanent test fixture) and blocks `>= 10325789`. Older testnet witnesses are not guaranteed and cannot be backfilled. |
 
-Requesting a testnet block outside this range returns `Witness not found`.
+Requesting a testnet block outside this range typically returns `Witness not found`.
 
 ### Decoding pipeline
 

--- a/docs/node/witness.md
+++ b/docs/node/witness.md
@@ -92,14 +92,25 @@ The response `result` is a single string of the form `<version>:<base64-payload>
 
 ### Errors
 
-| Code     | Cause                                                                       |
-| -------- | --------------------------------------------------------------------------- |
-| `-32602` | Invalid params — malformed JSON, missing `blockNumber`, or unparseable hex. |
-| `-32000` | Witness not found — no witness stored for the requested keys.               |
-| `-32001` | Decompression failed — stored payload is corrupted (server-side issue).     |
+| Code     | Cause                                                                                                         |
+| -------- | ------------------------------------------------------------------------------------------------------------- |
+| `-32602` | Invalid params — malformed JSON, missing `blockNumber`, unparseable hex, or an invalid parameter combination. |
+| `-32603` | Witness not found for the requested keys, or a server-side failure while fetching it.                         |
 
-The server returns `-32000` (a 404 equivalent) when no witness exists for the requested keys.
-The RPC layer in front of the witness service may also return standard JSON-RPC transport codes: `-32700` (parse error), `-32600` (invalid request), `-32603` (internal error).
+A missing witness and a server-side fetch failure both surface as `-32603`; the error `message` (for example `Witness not found`) distinguishes them.
+Note that `Witness not found` can be an expected outcome, not an error condition — see [Historical coverage](#historical-coverage) below.
+The RPC layer in front of the witness service may also return standard JSON-RPC transport codes: `-32700` (parse error), `-32600` (invalid request).
+
+### Historical coverage
+
+Witness availability on the public RPC depends on the network:
+
+| Network | Coverage                                                                                                                                           |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mainnet | All blocks.                                                                                                                                        |
+| Testnet | Block `1000` (a permanent test fixture) and blocks `>= 10325789`. Older testnet witnesses are at best sparsely available and cannot be backfilled. |
+
+Requesting a testnet block outside this range returns `Witness not found`.
 
 ### Decoding pipeline
 


### PR DESCRIPTION
## Summary
- Correct the `mega_getBlockWitness` error table in `docs/node/witness.md`: a missing witness or a server-side fetch failure returns `-32603` (with a distinguishing `message` such as `Witness not found`); the previously documented `-32000` / `-32001` codes are not returned.
- Add a "Historical coverage" section to `docs/node/witness.md`: mainnet serves witnesses for all blocks, while testnet only guarantees block `1000` and blocks `>= 10325789`, so `Witness not found` is an expected outcome outside that range.
- Qualify the quick-start hint in `docs/node/debug-trace-server.md` accordingly instead of claiming all historical blocks are served on every network.

## Test plan
- `npx prettier --check` passes on both files.
- Error codes and per-network coverage verified against the current public RPC gateway behavior.