### PR TITLE
fix: use one identity for PR review publication

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -25,6 +25,12 @@ The `interactive` action does not accept `extra_prompt` because `@claude` is nat
 
 The `pr-review` action additionally accepts:
 
+- `github_identity_token` - optional, defaults to empty.
+  When supplied, this token is the single identity for creating reviews,
+  posting or updating status comments, and resolving addressed automated
+  review threads.
+  When omitted, publication uses the job token and leaves GitHub thread state
+  unchanged.
 - `model` - optional, defaults to `claude-opus-4-7`.
   This strong model handles initial, high-risk, and explicitly deep reviews.
 - `incremental_model` - optional, defaults to empty, which uses the Claude Code default
@@ -37,6 +43,13 @@ The `pr-review` action additionally accepts:
   Automatic mode runs the independent production-failure analysis for initial and high-risk
   reviews, but skips it for ordinary incremental updates.
   `on` always enables it and `off` disables it.
+
+Consumers that already create a GitHub App token can opt into the unified identity with:
+
+```yaml
+with:
+  github_identity_token: ${{ steps.app-token.outputs.token }}
+```
 
 The semantic stage is bounded to 12 turns for fast incremental reviews, 24 for standard
 full or high-risk reviews, and 40 for explicit deep reviews.
@@ -53,8 +66,8 @@ The PR reviewer is an explicit staged pipeline:
 3. A deterministic compiler validates findings, enforces severity budgets, checks RIGHT-side
    anchors, formats the standard human-facing messages, and suppresses internal review
    machinery.
-4. A deterministic publisher rechecks the live head, submits at most one review, resolves
-   addressed automated threads, and updates one sticky status comment.
+4. A deterministic publisher rechecks the live head, submits at most one review, optionally
+   resolves addressed automated threads, and updates one sticky status comment.
 
 The sticky comment contains a hidden, versioned manifest with the last published head,
 reviewer and rubric versions, stable finding IDs, thread IDs, and finding dispositions.
@@ -64,8 +77,10 @@ The manifest never contains complete diffs, PR prose, tool output, secrets, or C
 transcripts.
 Inline findings are linked back to the exact published review and comment IDs, with bounded
 retries for GitHub API propagation.
-The publisher does not mark an inline finding resolved unless GitHub confirms the thread
-resolution mutation.
+When `github_identity_token` is configured, the publisher does not mark a GitHub thread
+resolved unless GitHub confirms the resolution mutation.
+The configured identity is stored in the review manifest while historical `claude` and
+`github-actions` state remains readable for migration.
 
 The action performs a full review when there is no valid checkpoint, the previous head is not
 an ancestor, or the pipeline or rubric version changed.

--- a/.github/actions/claude-pr-review/action.yml
+++ b/.github/actions/claude-pr-review/action.yml
@@ -5,6 +5,13 @@ inputs:
   claude_code_oauth_token:
     required: true
     description: OAuth token for Claude Code.
+  github_identity_token:
+    required: false
+    default: ""
+    description: >
+      Optional GitHub token used for review publication and state updates.
+      When supplied, it is also used to resolve addressed automated review
+      threads. Empty uses the job token and skips thread resolution.
   allowed_bots:
     required: false
     default: mega-putin
@@ -62,7 +69,7 @@ runs:
       id: prepare
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.github_identity_token || github.token }}
         REVIEW_DEPTH: ${{ inputs.review_depth }}
         PREMORTEM: ${{ inputs.premortem }}
         STATE_DIR: ${{ github.workspace }}/.pr-review
@@ -248,7 +255,8 @@ runs:
       id: publish
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.github_identity_token || github.token }}
+        GH_RESOLVE_THREADS: ${{ inputs.github_identity_token != '' }}
         STATE_DIR: ${{ github.workspace }}/.pr-review
       run: |
         set -euo pipefail

--- a/.github/actions/claude-pr-review/review_pipeline.py
+++ b/.github/actions/claude-pr-review/review_pipeline.py
@@ -52,11 +52,9 @@ HIGH_RISK_PARTS = {
     "security",
     "storage",
 }
-REVIEWER_LOGINS = {
+LEGACY_REVIEWER_LOGINS = {
     "claude",
-    "claude[bot]",
     "github-actions",
-    "github-actions[bot]",
 }
 GITHUB_LINK_RETRY_ATTEMPTS = 5
 GITHUB_LINK_RETRY_DELAY_SECONDS = 1
@@ -114,6 +112,23 @@ def gh_pages(endpoint: str) -> list[Any]:
         if isinstance(page, list):
             flattened.extend(page)
     return flattened
+
+
+def authenticated_login() -> str:
+    response = gh_json(
+        [
+            "api",
+            "graphql",
+            "-f",
+            "query=query { viewer { login } }",
+        ]
+    )
+    login = str(
+        (response or {}).get("data", {}).get("viewer", {}).get("login") or ""
+    )
+    if not login:
+        raise PipelineError("could not determine GitHub publisher identity")
+    return login
 
 
 def utc_now() -> str:
@@ -239,17 +254,37 @@ def is_high_risk(paths: list[str]) -> bool:
     return False
 
 
-def is_bot_login(login: str | None) -> bool:
+def canonical_login(login: str | None) -> str:
     lowered = (login or "").lower()
-    return lowered in REVIEWER_LOGINS
+    return lowered.removesuffix("[bot]")
 
 
-def is_stateful_review(login: str | None, body: str | None) -> bool:
-    lowered = (login or "").lower()
-    if lowered in {"claude", "claude[bot]"}:
+def reviewer_logins(publisher_login: str | None = None) -> set[str]:
+    logins = set(LEGACY_REVIEWER_LOGINS)
+    if publisher_login:
+        logins.add(canonical_login(publisher_login))
+    return logins
+
+
+def is_bot_login(
+    login: str | None,
+    *,
+    publisher_login: str | None = None,
+) -> bool:
+    return canonical_login(login) in reviewer_logins(publisher_login)
+
+
+def is_stateful_review(
+    login: str | None,
+    body: str | None,
+    *,
+    publisher_login: str | None = None,
+) -> bool:
+    lowered = canonical_login(login)
+    if lowered == "claude":
         return True
     return (
-        lowered in {"github-actions", "github-actions[bot]"}
+        lowered in reviewer_logins(publisher_login)
         and decode_state(body or "") is not None
     )
 
@@ -259,17 +294,22 @@ def is_owned_review_comment(
     *,
     repository: str,
     pull_request: int,
+    publisher_login: str | None = None,
 ) -> bool:
-    login = str((comment.get("author") or {}).get("login") or "").lower()
-    if login in {"claude", "claude[bot]"}:
+    login = canonical_login((comment.get("author") or {}).get("login"))
+    if login == "claude":
         return True
-    if login not in {"github-actions", "github-actions[bot]"}:
+    if login not in reviewer_logins(publisher_login):
         return False
     review = comment.get("pullRequestReview") or {}
     review_login = (review.get("author") or {}).get("login")
     state = decode_state(str(review.get("body") or ""))
     return (
-        is_stateful_review(review_login, str(review.get("body") or ""))
+        is_stateful_review(
+            review_login,
+            str(review.get("body") or ""),
+            publisher_login=publisher_login,
+        )
         and valid_manifest(
             state,
             repository=repository,
@@ -327,10 +367,11 @@ def load_sticky_state(
     *,
     repository: str,
     pull_request: int,
+    publisher_login: str | None = None,
 ) -> tuple[dict[str, Any] | None, int | None]:
     for comment in reversed(comments):
         login = (comment.get("user") or {}).get("login")
-        if not is_bot_login(login):
+        if not is_bot_login(login, publisher_login=publisher_login):
             continue
         body = comment.get("body") or ""
         state = decode_state(body)
@@ -339,7 +380,13 @@ def load_sticky_state(
             repository=repository,
             pull_request=pull_request,
         ):
-            return state, int(comment["id"])
+            editable_comment_id = (
+                int(comment["id"])
+                if not publisher_login
+                or canonical_login(login) == canonical_login(publisher_login)
+                else None
+            )
+            return state, editable_comment_id
     return None, None
 
 
@@ -348,9 +395,13 @@ def load_review_state(
     *,
     repository: str,
     pull_request: int,
+    publisher_login: str | None = None,
 ) -> dict[str, Any] | None:
     for review in reversed(reviews):
-        if not is_bot_login((review.get("user") or {}).get("login")):
+        if not is_bot_login(
+            (review.get("user") or {}).get("login"),
+            publisher_login=publisher_login,
+        ):
             continue
         body = review.get("body") or ""
         state = decode_state(body)
@@ -388,12 +439,20 @@ def compare_commits(
     return value if isinstance(value, dict) else None
 
 
-def latest_reviewed_head(reviews: list[dict[str, Any]]) -> str | None:
+def latest_reviewed_head(
+    reviews: list[dict[str, Any]],
+    *,
+    publisher_login: str | None = None,
+) -> str | None:
     for review in reversed(reviews):
         login = (review.get("user") or {}).get("login")
         commit_id = review.get("commit_id")
         if (
-            is_stateful_review(login, str(review.get("body") or ""))
+            is_stateful_review(
+                login,
+                str(review.get("body") or ""),
+                publisher_login=publisher_login,
+            )
             and commit_id
         ):
             return str(commit_id)
@@ -470,6 +529,8 @@ query($owner:String!, $name:String!, $number:Int!, $cursor:String) {
 def import_legacy_findings(
     manifest: dict[str, Any],
     threads: list[dict[str, Any]],
+    *,
+    publisher_login: str | None = None,
 ) -> None:
     known_threads: dict[str, dict[str, Any]] = {}
     known_comments: dict[int, dict[str, Any]] = {}
@@ -489,6 +550,7 @@ def import_legacy_findings(
             first,
             repository=str(manifest.get("repository") or ""),
             pull_request=int(manifest.get("pull_request") or 0),
+            publisher_login=publisher_login,
         ):
             continue
         thread_id = thread.get("id")
@@ -587,6 +649,7 @@ def prepare(args: argparse.Namespace) -> None:
             action_dir / "premortem.md",
         ]
     )
+    publisher_login = authenticated_login()
 
     pull = gh_json(
         ["api", f"repos/{args.repository}/pulls/{args.pull_request}"]
@@ -615,11 +678,13 @@ def prepare(args: argparse.Namespace) -> None:
         comments,
         repository=args.repository,
         pull_request=args.pull_request,
+        publisher_login=publisher_login,
     )
     review_state = load_review_state(
         reviews,
         repository=args.repository,
         pull_request=args.pull_request,
+        publisher_login=publisher_login,
     )
     prior_state = sticky_state or review_state
     manifest = (
@@ -632,12 +697,19 @@ def prepare(args: argparse.Namespace) -> None:
             rubric_version=rubric_version,
         )
     )
-    import_legacy_findings(manifest, threads)
+    import_legacy_findings(
+        manifest,
+        threads,
+        publisher_login=publisher_login,
+    )
     sync_manifest_threads(manifest, threads)
 
     previous_head = (
         manifest.get("cursor", {}).get("last_published_head")
-        or latest_reviewed_head(reviews)
+        or latest_reviewed_head(
+            reviews,
+            publisher_login=publisher_login,
+        )
     )
     version_matches = (
         prior_state is not None
@@ -646,6 +718,10 @@ def prepare(args: argparse.Namespace) -> None:
         and manifest.get("reviewer", {}).get("rubric_version") == rubric_version
         and manifest.get("reviewer", {}).get("model_policy_version")
         == MODEL_POLICY_VERSION
+        and canonical_login(
+            manifest.get("reviewer", {}).get("publisher_login")
+        )
+        == canonical_login(publisher_login)
     )
 
     mode = "full"
@@ -776,6 +852,7 @@ def prepare(args: argparse.Namespace) -> None:
         "review_threads": threads,
         "commentable_lines": commentable_lines,
         "sticky_comment_id": sticky_comment_id,
+        "publisher_login": publisher_login,
         "pipeline_version": pipeline_version,
         "rubric_version": rubric_version,
     }
@@ -1170,6 +1247,7 @@ def compile_review(
         "pipeline_version": review_input["pipeline_version"],
         "rubric_version": review_input["rubric_version"],
         "model_policy_version": MODEL_POLICY_VERSION,
+        "publisher_login": review_input.get("publisher_login"),
     }
     round_value = {
         "round_id": round_id,
@@ -1207,6 +1285,7 @@ def compile_review(
         "schema_version": SCHEMA_VERSION,
         "repository": review_input["repository"],
         "pull_request": review_input["pull_request"],
+        "publisher_login": review_input.get("publisher_login"),
         "frozen_head": head,
         "base_sha": review_input["pull_request_data"]["base_sha"],
         "mode": scope["mode"],
@@ -1249,13 +1328,15 @@ def existing_round_review(
     pull_request: int,
     marker: str,
     commit_id: str,
+    *,
+    publisher_login: str | None = None,
 ) -> int | None:
     reviews = gh_pages(
         f"repos/{repository}/pulls/{pull_request}/reviews?per_page=100"
     )
     for review in reversed(reviews):
         login = str((review.get("user") or {}).get("login") or "")
-        if not is_bot_login(login):
+        if not is_bot_login(login, publisher_login=publisher_login):
             continue
         if str(review.get("commit_id") or "") != commit_id:
             continue
@@ -1358,6 +1439,7 @@ def submit_review(
         payload["pull_request"],
         payload["round_marker"],
         payload["frozen_head"],
+        publisher_login=payload.get("publisher_login"),
     )
     if existing is not None:
         posted, inline_published = recover_existing_review(
@@ -1405,6 +1487,7 @@ def submit_review(
             pull_request,
             payload["round_marker"],
             payload["frozen_head"],
+            publisher_login=payload.get("publisher_login"),
         )
         if existing is not None:
             posted, inline_published = recover_existing_review(
@@ -1457,8 +1540,12 @@ def submit_review(
 def resolve_threads(
     thread_ids: list[str],
     *,
+    enabled: bool = False,
     before_write: Callable[[], None] | None = None,
 ) -> set[str]:
+    if not enabled:
+        return set()
+
     mutation = """
 mutation($threadId:ID!) {
   resolveReviewThread(input:{threadId:$threadId}) {
@@ -1683,6 +1770,7 @@ def publish(args: argparse.Namespace) -> None:
         )
         resolve_threads(
             payload["resolve_thread_ids"],
+            enabled=os.environ.get("GH_RESOLVE_THREADS", "").lower() == "true",
             before_write=require_frozen_pull,
         )
 

--- a/.github/actions/claude-pr-review/test_review_pipeline.py
+++ b/.github/actions/claude-pr-review/test_review_pipeline.py
@@ -41,6 +41,7 @@ def review_input(*, mode: str = "full"):
         "review_threads": [],
         "commentable_lines": {"src/example.py": [10, 11, 12]},
         "sticky_comment_id": None,
+        "publisher_login": "github-actions[bot]",
         "pipeline_version": "sha256:pipeline",
         "rubric_version": "sha256:rubric",
     }
@@ -80,7 +81,23 @@ class ReviewPipelineTests(unittest.TestCase):
         self.assertIn("Read,Glob,Grep,StructuredOutput,", action)
         self.assertIn("id: review_retry", action)
         self.assertIn("MUST call the\n          StructuredOutput tool", action)
-        self.assertIn("GH_TOKEN: ${{ github.token }}", action)
+
+    def test_action_exposes_optional_github_identity_token(self):
+        action = Path(pipeline.__file__).with_name("action.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("github_identity_token:", action)
+        identity_env = (
+            "GH_TOKEN: "
+            "${{ inputs.github_identity_token || github.token }}"
+        )
+        self.assertEqual(action.count(identity_env), 2)
+        self.assertIn(
+            "GH_RESOLVE_THREADS: "
+            "${{ inputs.github_identity_token != '' }}",
+            action,
+        )
         self.assertNotIn("GH_TOKEN: ${{ steps.review", action)
 
     def test_output_schema_uses_action_compatible_dialect(self):
@@ -152,6 +169,20 @@ class ReviewPipelineTests(unittest.TestCase):
         self.assertTrue(pipeline.is_bot_login("github-actions"))
         self.assertTrue(pipeline.is_bot_login("github-actions[bot]"))
         self.assertFalse(pipeline.is_bot_login("unrelated-bot[bot]"))
+        self.assertTrue(
+            pipeline.is_bot_login(
+                "mega-ci[bot]",
+                publisher_login="mega-ci[bot]",
+            )
+        )
+
+    @mock.patch.object(pipeline, "gh_json")
+    def test_authenticated_login_uses_active_github_identity(self, gh_json_mock):
+        gh_json_mock.return_value = {
+            "data": {"viewer": {"login": "mega-ci[bot]"}}
+        }
+
+        self.assertEqual(pipeline.authenticated_login(), "mega-ci[bot]")
 
     def test_latest_reviewed_head_ignores_unrelated_actions_review(self):
         state = review_input()["manifest"]
@@ -199,6 +230,50 @@ class ReviewPipelineTests(unittest.TestCase):
         self.assertEqual(loaded, state)
         self.assertEqual(comment_id, 2)
 
+    def test_identity_migration_reads_legacy_sticky_without_editing_it(self):
+        state = review_input()["manifest"]
+        marker = (
+            f"{pipeline.STATE_MARKER_PREFIX}{pipeline.encode_state(state)} -->"
+        )
+
+        loaded, comment_id = pipeline.load_sticky_state(
+            [
+                {
+                    "id": 2,
+                    "body": marker,
+                    "user": {"login": "github-actions[bot]"},
+                }
+            ],
+            repository="megaeth-labs/example",
+            pull_request=7,
+            publisher_login="mega-ci[bot]",
+        )
+
+        self.assertEqual(loaded, state)
+        self.assertIsNone(comment_id)
+
+    def test_configured_identity_can_update_its_sticky_state(self):
+        state = review_input()["manifest"]
+        marker = (
+            f"{pipeline.STATE_MARKER_PREFIX}{pipeline.encode_state(state)} -->"
+        )
+
+        loaded, comment_id = pipeline.load_sticky_state(
+            [
+                {
+                    "id": 3,
+                    "body": marker,
+                    "user": {"login": "mega-ci[bot]"},
+                }
+            ],
+            repository="megaeth-labs/example",
+            pull_request=7,
+            publisher_login="mega-ci",
+        )
+
+        self.assertEqual(loaded, state)
+        self.assertEqual(comment_id, 3)
+
     def test_review_body_is_manifest_fallback(self):
         state = review_input()["manifest"]
         marker = (
@@ -216,6 +291,27 @@ class ReviewPipelineTests(unittest.TestCase):
             pull_request=7,
         )
         self.assertEqual(loaded["cursor"]["review_id"], 42)
+
+    def test_configured_identity_review_is_manifest_fallback(self):
+        state = review_input()["manifest"]
+        marker = (
+            f"{pipeline.STATE_MARKER_PREFIX}{pipeline.encode_state(state)} -->"
+        )
+
+        loaded = pipeline.load_review_state(
+            [
+                {
+                    "id": 43,
+                    "body": marker,
+                    "user": {"login": "mega-ci[bot]"},
+                }
+            ],
+            repository="megaeth-labs/example",
+            pull_request=7,
+            publisher_login="mega-ci[bot]",
+        )
+
+        self.assertEqual(loaded["cursor"]["review_id"], 43)
 
     def test_inline_fallback_review_restores_body_only_finding(self):
         state = review_input()["manifest"]
@@ -284,6 +380,44 @@ class ReviewPipelineTests(unittest.TestCase):
         self.assertEqual(finding["thread_id"], "THREAD")
         self.assertEqual(finding["comment_id"], 99)
         self.assertTrue(finding["thread_required"])
+
+    def test_configured_identity_thread_links_from_stateful_review(self):
+        manifest = review_input()["manifest"]
+        state = review_input()["manifest"]
+        marker = (
+            f"{pipeline.STATE_MARKER_PREFIX}{pipeline.encode_state(state)} -->"
+        )
+        thread = {
+            "id": "THREAD",
+            "isResolved": False,
+            "comments": {
+                "nodes": [
+                    {
+                        "databaseId": 99,
+                        "body": "**[Major]** Finding",
+                        "path": "src/example.py",
+                        "line": 11,
+                        "url": "https://example.test/thread",
+                        "author": {"login": "mega-ci[bot]"},
+                        "pullRequestReview": {
+                            "databaseId": 42,
+                            "body": marker,
+                            "author": {"login": "mega-ci[bot]"},
+                        },
+                    }
+                ]
+            },
+        }
+
+        pipeline.import_legacy_findings(
+            manifest,
+            [thread],
+            publisher_login="mega-ci[bot]",
+        )
+
+        finding = next(iter(manifest["findings"].values()))
+        self.assertEqual(finding["thread_id"], "THREAD")
+        self.assertEqual(finding["comment_id"], 99)
 
     def test_unresolved_github_thread_reopens_manifest_finding(self):
         manifest = review_input()["manifest"]
@@ -531,6 +665,31 @@ class ReviewPipelineTests(unittest.TestCase):
         )
 
     @mock.patch.object(pipeline, "gh_pages")
+    def test_existing_round_review_accepts_configured_identity(
+        self,
+        pages_mock,
+    ):
+        pages_mock.return_value = [
+            {
+                "id": 4,
+                "body": "<!-- round -->",
+                "commit_id": "head",
+                "user": {"login": "mega-ci[bot]"},
+            }
+        ]
+
+        self.assertEqual(
+            pipeline.existing_round_review(
+                "megaeth-labs/example",
+                7,
+                "<!-- round -->",
+                "head",
+                publisher_login="mega-ci[bot]",
+            ),
+            4,
+        )
+
+    @mock.patch.object(pipeline, "gh_pages")
     @mock.patch.object(pipeline, "existing_round_review", return_value=None)
     @mock.patch.object(pipeline, "run")
     def test_review_submission_is_one_atomic_request(
@@ -647,7 +806,10 @@ class ReviewPipelineTests(unittest.TestCase):
                 }
             }
         }
-        self.assertEqual(pipeline.resolve_threads(["THREAD"]), {"THREAD"})
+        self.assertEqual(
+            pipeline.resolve_threads(["THREAD"], enabled=True),
+            {"THREAD"},
+        )
 
         gh_json_mock.return_value = {
             "data": {
@@ -660,7 +822,25 @@ class ReviewPipelineTests(unittest.TestCase):
             pipeline.PipelineError,
             "did not confirm resolution",
         ):
-            pipeline.resolve_threads(["THREAD"])
+            pipeline.resolve_threads(["THREAD"], enabled=True)
+
+    @mock.patch.object(pipeline, "gh_json")
+    def test_thread_resolution_is_skipped_without_explicit_identity(
+        self,
+        gh_json_mock,
+    ):
+        before_write = mock.Mock()
+
+        self.assertEqual(
+            pipeline.resolve_threads(
+                ["THREAD"],
+                before_write=before_write,
+            ),
+            set(),
+        )
+
+        gh_json_mock.assert_not_called()
+        before_write.assert_not_called()
 
     @mock.patch.object(pipeline, "submit_review")
     @mock.patch.object(pipeline, "gh_json")


### PR DESCRIPTION
## Summary
- add an optional github_identity_token that becomes the single identity for review preparation, review creation, status updates, and thread resolution
- keep the job token as the default publishing identity while skipping thread resolution unless a stronger token is explicitly supplied
- discover and persist the active publisher login while preserving legacy claude and github-actions review state across identity migration
- avoid editing sticky state owned by a previous publishing identity and add regression coverage for configured and default identities

## Test plan
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s .github/actions/claude-pr-review -p "test_*.py"
- Prettier check for the action metadata and README
- markdownlint-cli2 .github/actions/README.md
- git diff --check