### PR TITLE
ci: run pr-review under the CI app identity

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -67,8 +67,21 @@ jobs:
       id-token: write
       actions: read
     steps:
+      # Review under the CI app identity rather than the job token: it is what
+      # lets the action resolve stale review threads (the shared action gates
+      # --resolve-threads on github_identity_token being non-empty).
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.MEGA_CI_APP_PK }}
+          owner: megaeth-labs
+          repositories: documentation
+
       - uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Detect claude workflow changes
@@ -92,4 +105,5 @@ jobs:
         if: steps.workflow-change.outputs.skip != 'true'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_identity_token: ${{ steps.app-token.outputs.token }}
           allowed_bots: "mega-putin"


### PR DESCRIPTION
## Summary

- Mint a CI app token in the `pr-review` job and pass it to the action as `github_identity_token`.

The `claude-pr-review` action gates review-thread resolution on `github_identity_token` being non-empty. With only the job token, the action publishes reviews and updates the sticky status, but every addressed automated thread stays open — the author fixes the code and the thread never closes.

Also checks out under the app identity with `persist-credentials: false`, matching the pattern already in use in `stateless-validator`.

## Test plan

- Note this repo self-skips `pr-review` on any PR that touches `.github/workflows/claude.yml`, so this PR does not exercise the change. Verification happens on the next unrelated PR: the `app-token` step must succeed, and an addressed automated thread must end up resolved.
- A failing `app-token` step means the CI app is not installed on this repo or the org secret is not scoped to it.