### PR TITLE
Update faucet distribution amounts

### DIFF
--- a/docs/user/faq.md
+++ b/docs/user/faq.md
@@ -28,7 +28,7 @@ If you are on the Fluffle whitelist, registered via Discord, active in Telegram,
 ### Is the faucet capped?
 
 Yes.
-The faucet provides a maximum of 0.005 testnet ETH per user every 24 hours.
+The faucet provides 1 testnet ETH, 100 testnet USDM, and 1,000 testnet MEGA per user every 24 hours.
 
 ### Can I use different wallets to get more ETH from the faucet?
 

--- a/docs/user/faucet.md
+++ b/docs/user/faucet.md
@@ -25,7 +25,7 @@ If you are on the Fluffle whitelist, registered via Discord, active in Telegram,
 
 ## Limits
 
-- The faucet provides a maximum of **0.005 testnet ETH** per user every 24 hours.
+- The faucet provides **1 testnet ETH**, **100 testnet USDM**, and **1,000 testnet MEGA** per user every 24 hours.
 - Requests are tracked by IP address. Switching wallets will not bypass the limit.
 - If you need more testnet ETH to deploy and test a protocol, reach out to the team directly.
 

--- a/docs/user/get-started.md
+++ b/docs/user/get-started.md
@@ -53,7 +53,7 @@ See [Get Funds on Mainnet](bridge.md) for more options including third-party bri
 
 {% tab title="Testnet" %}
 Visit the faucet at [testnet.megaeth.com](https://testnet.megaeth.com), enter your wallet address, and complete the verification step.
-The faucet provides up to 0.005 testnet ETH per user every 24 hours.
+The faucet provides 1 testnet ETH, 100 testnet USDM, and 1,000 testnet MEGA per user every 24 hours.
 See the [Faucet](faucet.md) page for details.
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
## Summary

- Update all User Guide faucet references to the current distribution amounts.
- Document 1 testnet ETH, 100 testnet USDM, and 1,000 testnet MEGA per user every 24 hours.

## Rationale

The documentation still stated that the faucet distributed 0.005 testnet ETH and did not mention USDM or MEGA. This update aligns the Faucet page, Get Started guide, and User FAQ with the current distribution.

## User impact

Users can see the full token amounts they receive before requesting funds from the faucet.

## Validation

- `markdownlint-cli2`: 0 issues
- `prettier@3.8.5 --check **/*.md`: passed
- `lychee 0.24.2 **/*.md`: 440 links valid, 0 errors
- No stale `0.005` faucet references remain
- `git diff --check`: passed